### PR TITLE
Fix for RTS issues w/ the WHOI MicroModem2 in Linux.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Entities:
 To accept this CLA, please add your name, email, and date to the list below, and commit the change using your name and email. Committing your name electronically with your SSH key will be considered a substitute for your physical signature:
 
 Toby Schneider <toby@gobysoft.org> 2016-05-13
+Zac Berkowitz <zberkowitz@whoi.edu> 2016-05-19

--- a/src/acomms/modemdriver/mm_driver.cpp
+++ b/src/acomms/modemdriver/mm_driver.cpp
@@ -111,6 +111,19 @@ void goby::acomms::MMDriver::startup(const protobuf::DriverConfig& cfg)
     
     modem_start(driver_cfg_);
 
+    // Grab our native file descrpitor for the serial port.  Only works for linux.
+    // Used to change control lines (e.g. RTS) w/ linux through IOCTL calls.
+    // Would need #ifdef's for conditional compling if other platforms become desired.
+    serial_fd_ = dynamic_cast<util::SerialClient&>(modem()).socket().native();
+
+    // The MM2 (at least, possibly MM1 as well) has an issue where serial comms are
+    // garbled when RTS is asserted and hardware flow control is disabled (HFC0).
+    // HFC is disabled by default on MM boot so we need to make sure 
+    // RTS is low to talk to it.  Lines besides TX/RX/GND are rarely wired into
+    // MM units, but the newer MM2 development boxes full 9-line serial passthrough.
+        
+    set_rts(false);
+
     write_cfg();
 
     // reboot, to ensure we get a $CAREV message
@@ -142,6 +155,33 @@ void goby::acomms::MMDriver::startup(const protobuf::DriverConfig& cfg)
     query_all_cfg();
 
     startup_done_ = true;
+}
+
+void goby::acomms::MMDriver::set_rts(bool state)
+{
+    int status;
+    if(ioctl(serial_fd_, TIOCMGET, &status) == -1)
+    {
+        glog.is(DEBUG1) && glog << group(glog_out_group()) << warn << "IOCTL failed: " << strerror(errno) << std::endl;            
+    }
+    
+    glog.is(DEBUG1) && glog << group(glog_out_group()) << "Setting RTS to " << (state ? "high" : "low" ) << std::endl;
+    if(state) status |= TIOCM_RTS;
+    else status &= ~TIOCM_RTS;
+    if(ioctl(serial_fd_, TIOCMSET, &status) == -1)
+    {
+        glog.is(DEBUG1) && glog << group(glog_out_group()) << warn << "IOCTL failed: " << strerror(errno) << std::endl;            
+    }
+}
+
+bool goby::acomms::MMDriver::query_rts()
+{
+    int status;
+    if(ioctl(serial_fd_, TIOCMGET, &status) == -1)
+    {
+        glog.is(DEBUG1) && glog << group(glog_out_group()) << warn << "IOCTL failed: " << strerror(errno) << std::endl;            
+    }    
+    return (status & TIOCM_RTS);
 }
 
 void goby::acomms::MMDriver::update_cfg(const protobuf::DriverConfig& cfg)

--- a/src/acomms/modemdriver/mm_driver.h
+++ b/src/acomms/modemdriver/mm_driver.h
@@ -166,6 +166,10 @@ namespace goby
             void process_incoming_app_ack(protobuf::ModemTransmission* m);
             void process_outgoing_app_ack(protobuf::ModemTransmission* msg);
             
+	    // Serial port methods
+            void set_rts(bool state);
+            bool query_rts();
+            
             // doxygen
             
             /// \example acomms/modemdriver/driver_simple/driver_simple.cpp
@@ -181,7 +185,9 @@ namespace goby
             enum { RETRIES = 3 };
             enum { ROUGH_SPEED_OF_SOUND = 1500 }; // m/s
                 
-            
+	    
+            int serial_fd_;
+
             // seconds to wait for modem to respond
             static const boost::posix_time::time_duration MODEM_WAIT; 
             // seconds to wait after modem reboot

--- a/src/acomms/modemdriver/mm_driver.h
+++ b/src/acomms/modemdriver/mm_driver.h
@@ -184,9 +184,6 @@ namespace goby
             // how many retries on a given message
             enum { RETRIES = 3 };
             enum { ROUGH_SPEED_OF_SOUND = 1500 }; // m/s
-                
-	    
-            int serial_fd_;
 
             // seconds to wait for modem to respond
             static const boost::posix_time::time_duration MODEM_WAIT; 
@@ -301,6 +298,9 @@ namespace goby
             std::map<unsigned, std::set<unsigned> > frames_to_ack_;
 
             dccl::Codec dccl_;
+            
+            int serial_fd_;
+
         };
     }
 }


### PR DESCRIPTION
Explicitly set RTS pin inactive when opening a serial port for the WHOI MicroModem.

Serial comms with the MM2 are garbled when RTS is active, even when hardware flow control has been disabled on the port and the modem itself.  Linux by default opens a serial port with RTS active, even with hardware flow control disabled.
