### PR TITLE
HDF5 Scientific Data analysis writer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,7 @@ else()
 endif()
 
 ## HDF5
-find_package(HDF5 QUIET)
+find_package(HDF5 QUIET COMPONENTS C CXX)
 set(HDF5_DOC_STRING "Enable HDF5 file format tools (requires libhdf5-dev: https://www.hdfgroup.org/HDF5)")
 # find resources directory
 if(HDF5_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,18 @@ else()
   message(">> setting enable_sqlite to OFF ... if you need this functionality: 1) install libsqlite3-dev; 2) run cmake -Denable_sqlite=ON")
 endif()
 
+## HDF5
+find_package(HDF5 QUIET)
+set(HDF5_DOC_STRING "Enable HDF5 file format tools (requires libhdf5-dev: https://www.hdfgroup.org/HDF5)")
+# find resources directory
+if(HDF5_FOUND)
+  option(enable_hdf5 ${HDF5_DOC_STRING} ON)
+else()
+  option(enable_hdf5 ${HDF5_DOC_STRING} OFF)
+  message(">> setting enable_hdf5 to OFF ... if you need this functionality: 1) install libhdf5-dev; 2) run cmake -Denable_hdf5=ON")
+endif()
+
+
 
 ## Wt
 find_package(WtGoby QUIET)

--- a/src/apps/common/CMakeLists.txt
+++ b/src/apps/common/CMakeLists.txt
@@ -2,3 +2,7 @@
 if(enable_wt AND enable_zeromq)
   add_subdirectory(liaison)
 endif()
+
+if(enable_hdf5)
+  add_subdirectory(goby_hdf5)
+endif()

--- a/src/apps/common/goby_hdf5/CMakeLists.txt
+++ b/src/apps/common/goby_hdf5/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(goby_hdf5
   hdf5.cpp)
 
+
 target_link_libraries(goby_hdf5
   ${HDF5_LIBRARIES}
   ${PROTOBUF_LIBRARIES}

--- a/src/apps/common/goby_hdf5/CMakeLists.txt
+++ b/src/apps/common/goby_hdf5/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(goby_hdf5
+  hdf5.cpp)
+
+target_link_libraries(goby_hdf5
+  ${HDF5_LIBRARIES}
+  ${PROTOBUF_LIBRARIES}
+  goby_common
+)

--- a/src/apps/common/goby_hdf5/hdf5.cpp
+++ b/src/apps/common/goby_hdf5/hdf5.cpp
@@ -23,39 +23,14 @@
 #include <iostream>
 #include <cstdlib>
 
-#include "goby/common/application_base.h"
-#include "goby/common/protobuf/hdf5.pb.h"
-#include "goby/common/hdf5_plugin.h"
 #include "goby/common/logger.h"
+
+#include "hdf5.h"
 
 void* plugin_handle = 0;
 
-
-
-using goby::glog;
 using namespace goby::common::logger;
-
-
-class HDF5Writer : public goby::common::ApplicationBase
-{
-public:
-    HDF5Writer(goby::common::protobuf::HDF5Config* cfg);
-
-private:
-    void load();
-    void collect();
-    void write();
-    
-    void iterate() { }
-
-private:
-    goby::common::protobuf::HDF5Config& cfg_;
-    boost::shared_ptr<goby::common::HDF5Plugin> plugin_;
-
-    std::multimap<std::string, goby::common::HDF5ProtobufEntry> entries_;
-};
-
-
+using goby::glog;
 
 int main(int argc, char * argv[])
 {
@@ -78,13 +53,15 @@ int main(int argc, char * argv[])
     }
 
     goby::common::protobuf::HDF5Config cfg;
-    return goby::run<HDF5Writer>(argc, argv, &cfg);
+    return goby::run<goby::common::hdf5::Writer>(argc, argv, &cfg);
 }
 
 
-HDF5Writer::HDF5Writer(goby::common::protobuf::HDF5Config* cfg)
+goby::common::hdf5::Writer::Writer(goby::common::protobuf::HDF5Config* cfg)
     : ApplicationBase(cfg),
-      cfg_(*cfg)
+      cfg_(*cfg),
+      h5file_(cfg_.output_file(), H5F_ACC_TRUNC),
+      group_factory_(h5file_)
 {
     load();
     collect();
@@ -92,7 +69,7 @@ HDF5Writer::HDF5Writer(goby::common::protobuf::HDF5Config* cfg)
     quit();    
 }
 
-void HDF5Writer::load()
+void goby::common::hdf5::Writer::load()
 {
     typedef goby::common::HDF5Plugin* (*plugin_func)(goby::common::protobuf::HDF5Config*);
     plugin_func plugin_ptr = (plugin_func) dlsym(plugin_handle, "goby_hdf5_load");
@@ -104,25 +81,122 @@ void HDF5Writer::load()
     
     if(!plugin_)
         glog.is(DIE) && glog << "Function goby_hdf5_load in library defined in GOBY_HDF5_PLUGIN returned a null pointer." <<  std::endl;    
+
 }
 
 
-void HDF5Writer::collect()
+void goby::common::hdf5::Writer::collect()
 {
     goby::common::HDF5ProtobufEntry entry;
     while(plugin_->provide_entry(&entry))
     {
-        entries_.insert(std::make_pair(entry.channel, entry));
-        entry.clear();        
+        boost::trim_if(entry.channel, boost::algorithm::is_space() || boost::algorithm::is_any_of("/"));
+
+        typedef std::map<std::string, goby::common::hdf5::Channel>::iterator It;
+        It it = channels_.find(entry.channel);
+        if(it == channels_.end())
+        {
+            std::pair<It, bool> itpair = channels_.insert(std::make_pair(entry.channel, goby::common::hdf5::Channel(entry.channel)));
+            it = itpair.first;
+        }
+        
+        
+        it->second.add_message(entry);
+        entry.clear();
     }
 }
 
     
-void HDF5Writer::write()
+void goby::common::hdf5::Writer::write()
 {
-    for(std::multimap<std::string, goby::common::HDF5ProtobufEntry>::const_iterator it = entries_.begin(), n = entries_.end(); it != n; ++it)
-    {
-        std::cout << it->second << std::endl;
-    }
+    for(std::map<std::string, goby::common::hdf5::Channel>::const_iterator it = channels_.begin(), end = channels_.end(); it != end; ++it)
+        write_channel("/" + it->first, it->second);
 }
 
+void goby::common::hdf5::Writer::write_channel(const std::string& group, const goby::common::hdf5::Channel& channel)
+{
+    std::cout << "Channel: [" << channel.name << "]" << std::endl;
+    for(std::map<std::string, goby::common::hdf5::Message>::const_iterator it = channel.entries.begin(), end = channel.entries.end(); it != end; ++it)
+        write_message(group + "/" + it->first, it->second);    
+}
+
+
+void goby::common::hdf5::Writer::write_message(const std::string& group, const goby::common::hdf5::Message& message)
+{
+    std::cout << "Message: [" << message.name << "]" << std::endl;
+    std::cout << "group: [" << group << "]" << std::endl;
+
+    write_time(group, message);
+    
+    const google::protobuf::Descriptor* desc = message.entries.begin()->second->GetDescriptor();
+    for(int i = 0, n = desc->field_count(); i < n; ++i)
+    {
+        const google::protobuf::FieldDescriptor* field_desc = desc->field(i);
+        switch(field_desc->cpp_type())
+        {
+            case google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE:
+                break;
+                            
+            case google::protobuf::FieldDescriptor::CPPTYPE_ENUM:
+                break;
+                                
+            case google::protobuf::FieldDescriptor::CPPTYPE_INT32:
+                write_field<goby::int32>(group, field_desc, message);
+                break;
+                            
+            case google::protobuf::FieldDescriptor::CPPTYPE_INT64:
+                write_field<goby::int64>(group, field_desc, message);
+                break;
+                            
+            case google::protobuf::FieldDescriptor::CPPTYPE_UINT32:
+                write_field<goby::uint32>(group, field_desc, message);
+                break;
+                            
+            case google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
+                write_field<goby::uint64>(group, field_desc, message);
+                break;
+                            
+            case google::protobuf::FieldDescriptor::CPPTYPE_BOOL:
+                //write_field<bool>(group, field_desc, message);
+                break;
+                            
+            case google::protobuf::FieldDescriptor::CPPTYPE_STRING:
+                // if(field_desc->type() ==  google::protobuf::FieldDescriptor::TYPE_STRING)
+                //     write_field<std::string>(group, field_desc, message);
+                // else if(field_desc->type() ==  google::protobuf::FieldDescriptor::TYPE_BYTES)
+                //     write_field<std::string>(group, field_desc, message);
+                break;                    
+                
+            case google::protobuf::FieldDescriptor::CPPTYPE_FLOAT:                
+                write_field<float>(group, field_desc, message);
+                break;
+                            
+            case google::protobuf::FieldDescriptor::CPPTYPE_DOUBLE:
+                write_field<double>(group, field_desc, message);
+                break;
+        }
+
+    }
+    
+}
+
+
+void goby::common::hdf5::Writer::write_time(const std::string& group, const goby::common::hdf5::Message& message)
+{
+    std::vector<goby::uint64> utime(message.entries.size(), 0);
+    std::vector<double> datenum(message.entries.size(), 0);
+    int i = 0;
+    for(std::multimap<goby::uint64, boost::shared_ptr<google::protobuf::Message> >::const_iterator it = message.entries.begin(), end = message.entries.end(); it != end; ++it)
+    {
+        utime[i] = it->first;
+        // datenum(1970, 1, 1, 0, 0, 0)
+        const double datenum_unix_epoch = 719529;
+        const double seconds_in_day = 86400;
+        goby::uint64 utime_sec = utime[i]/1000000;
+        goby::uint64 utime_frac = utime[i] - utime_sec*1000000;
+        datenum[i] = datenum_unix_epoch + static_cast<double>(utime_sec)/seconds_in_day + static_cast<double>(utime_frac)/1000000/seconds_in_day;
+        ++i;
+    }
+    write_vector(group, "_utime_", utime);
+    write_vector(group, "_datenum_", datenum);
+}

--- a/src/apps/common/goby_hdf5/hdf5.cpp
+++ b/src/apps/common/goby_hdf5/hdf5.cpp
@@ -1,0 +1,128 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (2013-)
+//                     Massachusetts Institute of Technology (2007-2014)
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Binaries
+// ("The Goby Binaries").
+//
+// The Goby Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Goby Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <dlfcn.h>
+#include <iostream>
+#include <cstdlib>
+
+#include "goby/common/application_base.h"
+#include "goby/common/protobuf/hdf5.pb.h"
+#include "goby/common/hdf5_plugin.h"
+#include "goby/common/logger.h"
+
+void* plugin_handle = 0;
+
+
+
+using goby::glog;
+using namespace goby::common::logger;
+
+
+class HDF5Writer : public goby::common::ApplicationBase
+{
+public:
+    HDF5Writer(goby::common::protobuf::HDF5Config* cfg);
+
+private:
+    void load();
+    void collect();
+    void write();
+    
+    void iterate() { }
+
+private:
+    goby::common::protobuf::HDF5Config& cfg_;
+    boost::shared_ptr<goby::common::HDF5Plugin> plugin_;
+
+    std::multimap<std::string, goby::common::HDF5ProtobufEntry> entries_;
+};
+
+
+
+int main(int argc, char * argv[])
+{
+    // load plugin driver from environmental variable GOBY_HDF5_PLUGIN
+    const char* plugin_path = getenv ("GOBY_HDF5_PLUGIN");
+    if (plugin_path)
+    {
+        std::cerr << "Loading plugin library: " << plugin_path << std::endl;
+        plugin_handle = dlopen(plugin_path, RTLD_LAZY);
+        if(!plugin_handle)
+        {
+            std::cerr << "Failed to open library: " << plugin_path << std::endl;
+            exit(EXIT_FAILURE);
+        }
+    }        
+    else
+    {
+        std::cerr << "Environmental variable GOBY_HDF5_PLUGIN must be set with name of the dynamic library containing the specific frontend plugin to use." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    goby::common::protobuf::HDF5Config cfg;
+    return goby::run<HDF5Writer>(argc, argv, &cfg);
+}
+
+
+HDF5Writer::HDF5Writer(goby::common::protobuf::HDF5Config* cfg)
+    : ApplicationBase(cfg),
+      cfg_(*cfg)
+{
+    load();
+    collect();
+    write();
+    quit();    
+}
+
+void HDF5Writer::load()
+{
+    typedef goby::common::HDF5Plugin* (*plugin_func)(goby::common::protobuf::HDF5Config*);
+    plugin_func plugin_ptr = (plugin_func) dlsym(plugin_handle, "goby_hdf5_load");
+
+    if(!plugin_ptr)
+        glog.is(DIE) && glog << "Function goby_hdf5_load in library defined in GOBY_HDF5_PLUGIN does not exist." <<  std::endl;
+
+    plugin_.reset((*plugin_ptr)(&cfg_));
+    
+    if(!plugin_)
+        glog.is(DIE) && glog << "Function goby_hdf5_load in library defined in GOBY_HDF5_PLUGIN returned a null pointer." <<  std::endl;    
+}
+
+
+void HDF5Writer::collect()
+{
+    goby::common::HDF5ProtobufEntry entry;
+    while(plugin_->provide_entry(&entry))
+    {
+        entries_.insert(std::make_pair(entry.channel, entry));
+        entry.clear();        
+    }
+}
+
+    
+void HDF5Writer::write()
+{
+    for(std::multimap<std::string, goby::common::HDF5ProtobufEntry>::const_iterator it = entries_.begin(), n = entries_.end(); it != n; ++it)
+    {
+        std::cout << it->second << std::endl;
+    }
+}
+

--- a/src/apps/common/goby_hdf5/hdf5.h
+++ b/src/apps/common/goby_hdf5/hdf5.h
@@ -1,0 +1,284 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (2013-)
+//                     Massachusetts Institute of Technology (2007-2014)
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Binaries
+// ("The Goby Binaries").
+//
+// The Goby Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Goby Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef GOBYHDF520160524H
+#define GOBYHDF520160524H
+
+#include <boost/algorithm/string.hpp>
+
+#include "H5Cpp.h"
+
+#include "goby/common/hdf5_plugin.h"
+#include "goby/common/application_base.h"
+#include "goby/common/protobuf/hdf5.pb.h"
+
+namespace goby
+{
+    namespace common
+    {
+        namespace hdf5
+        {
+            template <typename T> H5::PredType predicate();
+            template<> H5::PredType predicate<goby::int32>() { return H5::PredType::NATIVE_INT32; }
+            template<> H5::PredType predicate<goby::int64>() { return H5::PredType::NATIVE_INT64; }
+            template<> H5::PredType predicate<goby::uint32>() { return H5::PredType::NATIVE_UINT32; }
+            template<> H5::PredType predicate<goby::uint64>() { return H5::PredType::NATIVE_UINT64; }
+            template<> H5::PredType predicate<float>() { return H5::PredType::NATIVE_FLOAT; }
+            template<> H5::PredType predicate<double>() { return H5::PredType::NATIVE_DOUBLE; }
+
+            template <typename T> void retrieve_single_value(T* val, const google::protobuf::Reflection* refl,  const google::protobuf::FieldDescriptor* field_desc, const google::protobuf::Message& msg);
+            
+            struct Message
+            {
+            Message(const std::string& n) : name(n) { }
+                std::string name;
+
+                // time -> Message contents
+                std::multimap<goby::uint64, boost::shared_ptr<google::protobuf::Message> > entries;
+            };
+    
+
+            struct Channel
+            {
+            Channel(const std::string& n) : name(n) { }
+                std::string name;
+
+                void add_message(const goby::common::HDF5ProtobufEntry& entry)
+                    {
+                        const std::string& msg_name = entry.msg->GetDescriptor()->full_name();
+                        typedef std::map<std::string, Message>::iterator It;
+                        It it = entries.find(msg_name);
+                        if(it == entries.end())
+                        {
+                            std::pair<It, bool> itpair = entries.insert(std::make_pair(msg_name, Message(msg_name)));
+                            it = itpair.first;
+                        }
+                        it->second.entries.insert(std::make_pair(entry.time, entry.msg));
+                    }
+    
+                // message name -> hdf5::Message
+                std::map<std::string, Message> entries;
+            };
+
+            // keeps track of HDF5 groups for us, and creates them as needed
+            class GroupFactory
+            {
+            public:
+            GroupFactory(H5::H5File& h5file) :
+                root_group_(h5file.openGroup("/"))
+                {
+                }
+
+                // creates or opens group
+                H5::Group& fetch_group(const std::string& group_path)
+                {
+                    std::deque<std::string> nodes;
+                    std::string clean_path = boost::trim_copy_if(group_path, boost::algorithm::is_space() || boost::algorithm::is_any_of("/"));
+                    boost::split(nodes, clean_path, boost::is_any_of("/"));
+                    return root_group_.fetch_group(nodes);
+                }
+    
+    
+            private:
+                class GroupWrapper
+                {
+                public:
+                    // for root group (already exists)
+                GroupWrapper(H5::Group group) : group_(group)
+                    { }
+
+                    // for children groups
+                    GroupWrapper(const std::string& name, H5::Group& parent)
+                    {
+                        group_ = parent.createGroup(name);
+                    }
+
+                    H5::Group& fetch_group(std::deque<std::string>& nodes)
+                    {
+                        if(nodes.empty())
+                        {
+                            return group_;
+                        }
+                        else
+                        {
+                            typedef std::map<std::string, GroupWrapper>::iterator It;
+                            It it = children_.find(nodes[0]);
+                            if(it == children_.end())
+                            {
+                                std::pair<It, bool> itpair = children_.insert(std::make_pair(nodes[0], GroupWrapper(nodes[0], group_)));
+                                it = itpair.first;
+                            }
+                            nodes.pop_front();
+                            return it->second.fetch_group(nodes); 
+                        }
+                    }
+        
+        
+                private:
+                    H5::Group group_;
+                    std::map<std::string, GroupWrapper> children_;
+                };
+                GroupWrapper root_group_;
+            };
+            
+            class Writer : public goby::common::ApplicationBase
+            {
+            public:
+                Writer(goby::common::protobuf::HDF5Config* cfg);
+
+            private:
+                void load();
+                void collect();
+                void write();
+                void write_channel(const std::string& group, const goby::common::hdf5::Channel& channel);
+                void write_message(const std::string& group, const goby::common::hdf5::Message& message);
+                void write_time(const std::string& group, const goby::common::hdf5::Message& message);
+
+
+                template<typename T>
+                    void write_field(const std::string& group, const google::protobuf::FieldDescriptor* field_desc, const goby::common::hdf5::Message& message)
+                {
+                    std::vector<T> values(message.entries.size(), 0);
+                    int i = 0;
+                    for(std::multimap<goby::uint64, boost::shared_ptr<google::protobuf::Message> >::const_iterator it = message.entries.begin(), end = message.entries.end(); it != end; ++it)
+                    {
+                        const google::protobuf::Reflection* refl = it->second->GetReflection();
+                        
+                        if(field_desc->is_repeated())
+                            continue; // TODO: support repeateds
+                        else
+                            retrieve_single_value<T>(&values[i], refl, field_desc, *it->second);
+                        
+                        ++i;
+                    }
+                    write_vector(group, field_desc->name(), values);
+                }
+                
+                template<typename T>
+                    void write_vector(const std::string& group, const std::string dataset_name, const std::vector<T>& data)
+                {
+                    const int rank = 1;
+                    hsize_t dimsf[] = {data.size()}; 
+                    H5::DataSpace dataspace(rank, dimsf, dimsf);
+                    H5::Group& grp = group_factory_.fetch_group(group);
+                    H5::DataSet dataset = grp.createDataSet(dataset_name,
+                                                            predicate<T>(),
+                                                            dataspace);
+                    dataset.write(&data[0], predicate<T>());
+                }
+                
+                
+                void iterate() { }
+
+            private:
+                goby::common::protobuf::HDF5Config& cfg_;
+                boost::shared_ptr<goby::common::HDF5Plugin> plugin_;
+
+                // channel name -> hdf5::Channel
+                std::map<std::string, goby::common::hdf5::Channel> channels_;
+                H5::H5File h5file_;
+
+                goby::common::hdf5::GroupFactory group_factory_;
+            };
+
+
+
+            template <>
+                void retrieve_single_value(goby::int32* val,
+                                           const google::protobuf::Reflection* refl,
+                                           const google::protobuf::FieldDescriptor* field_desc,
+                                           const google::protobuf::Message& msg)
+            {
+                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
+                    *val = std::numeric_limits<goby::int32>::max();
+                else
+                    *val = refl->GetInt32(msg, field_desc);
+            }
+
+            template <>
+                void retrieve_single_value(goby::uint32* val,
+                                           const google::protobuf::Reflection* refl,
+                                           const google::protobuf::FieldDescriptor* field_desc,
+                                           const google::protobuf::Message& msg)
+            {
+                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
+                    *val = std::numeric_limits<goby::uint32>::max();
+                else
+                    *val = refl->GetUInt32(msg, field_desc);
+            }
+
+            template <>
+                void retrieve_single_value(goby::int64* val,
+                                           const google::protobuf::Reflection* refl,
+                                           const google::protobuf::FieldDescriptor* field_desc,
+                                           const google::protobuf::Message& msg)
+            {
+                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
+                    *val = std::numeric_limits<goby::int64>::max();
+                else
+                    *val = refl->GetInt64(msg, field_desc);
+            }
+
+
+            template <>
+                void retrieve_single_value(goby::uint64* val,
+                                           const google::protobuf::Reflection* refl,
+                                           const google::protobuf::FieldDescriptor* field_desc,
+                                           const google::protobuf::Message& msg)
+            {
+                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
+                    *val = std::numeric_limits<goby::uint64>::max();
+                else
+                    *val = refl->GetUInt64(msg, field_desc);
+            }
+
+
+            template <>
+                void retrieve_single_value(double* val,
+                                           const google::protobuf::Reflection* refl,
+                                           const google::protobuf::FieldDescriptor* field_desc,
+                                           const google::protobuf::Message& msg)
+            {
+                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
+                    *val = std::numeric_limits<double>::quiet_NaN();
+                else
+                    *val = refl->GetDouble(msg, field_desc);
+            }
+
+            template <>
+                void retrieve_single_value(float* val,
+                                           const google::protobuf::Reflection* refl,
+                                           const google::protobuf::FieldDescriptor* field_desc,
+                                           const google::protobuf::Message& msg)
+            {
+                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
+                    *val = std::numeric_limits<float>::quiet_NaN();
+                else
+                    *val = refl->GetFloat(msg, field_desc);
+            }
+        }
+    }
+}
+
+
+
+
+#endif

--- a/src/apps/common/goby_hdf5/hdf5.h
+++ b/src/apps/common/goby_hdf5/hdf5.h
@@ -178,6 +178,8 @@ namespace goby
 
                 void write_field_selector(const std::string& group, const google::protobuf::FieldDescriptor* field_desc, const std::vector<const google::protobuf::Message* >& messages);
 
+                void write_enum_attributes(const std::string& group, const google::protobuf::FieldDescriptor* field_desc);
+                
                 template<typename T>
                     void write_field(const std::string& group, const google::protobuf::FieldDescriptor* field_desc, const std::vector<const google::protobuf::Message* >& messages)
                 {
@@ -317,10 +319,32 @@ namespace goby
             { *val = std::numeric_limits<goby::int32>::max(); }
             template <>
                 void retrieve_single_present_value(goby::int32* val, PBMeta m)
-            { *val = m.refl->GetInt32(m.msg, m.field_desc); }
+            {
+                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_INT32)
+                {
+                    *val = m.refl->GetInt32(m.msg, m.field_desc);
+                }
+                else if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_ENUM)
+                {
+                    const google::protobuf::EnumValueDescriptor* enum_desc =
+                        m.refl->GetEnum(m.msg, m.field_desc);
+                    *val = enum_desc->number();
+                }
+            }
             template <>
                 void retrieve_repeated_value(goby::int32* val, int index, PBMeta m)
-            { *val = m.refl->GetRepeatedInt32(m.msg, m.field_desc, index); }
+            {
+                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_INT32)
+                {
+                    *val = m.refl->GetRepeatedInt32(m.msg, m.field_desc, index);
+                }
+                else if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_ENUM)
+                {
+                    const google::protobuf::EnumValueDescriptor* enum_desc =
+                        m.refl->GetRepeatedEnum(m.msg, m.field_desc, index);
+                    *val = enum_desc->number();                    
+                }                
+            }
 
             template <>
                 void retrieve_empty_value(goby::uint32* val)

--- a/src/apps/common/goby_hdf5/hdf5.h
+++ b/src/apps/common/goby_hdf5/hdf5.h
@@ -29,6 +29,7 @@
 #include "goby/common/hdf5_plugin.h"
 #include "goby/common/application_base.h"
 #include "goby/common/protobuf/hdf5.pb.h"
+#include "goby/util/binary.h"
 
 namespace goby
 {
@@ -43,12 +44,35 @@ namespace goby
             template<> H5::PredType predicate<goby::uint64>() { return H5::PredType::NATIVE_UINT64; }
             template<> H5::PredType predicate<float>() { return H5::PredType::NATIVE_FLOAT; }
             template<> H5::PredType predicate<double>() { return H5::PredType::NATIVE_DOUBLE; }
-
-            template <typename T> void retrieve_single_value(T* val, const google::protobuf::Reflection* refl,  const google::protobuf::FieldDescriptor* field_desc, const google::protobuf::Message& msg);
-            
-            struct Message
+            template<> H5::PredType predicate<unsigned char>() { return H5::PredType::NATIVE_UCHAR; }
+ 
+            struct PBMeta
             {
-            Message(const std::string& n) : name(n) { }
+                PBMeta(const google::protobuf::Reflection* r,
+                       const google::protobuf::FieldDescriptor* f,
+                       const google::protobuf::Message& m) : refl(r), field_desc(f), msg(m)
+                    { }
+                
+                const google::protobuf::Reflection* refl;
+                const google::protobuf::FieldDescriptor* field_desc;
+                const google::protobuf::Message& msg;
+            };
+            
+            template <typename T> void retrieve_empty_value(T* val);            
+            template <typename T> void retrieve_single_value(T* val, PBMeta m)
+            {
+                if(m.field_desc->is_optional() && !m.refl->HasField(m.msg, m.field_desc))
+                    retrieve_empty_value(val);
+                else
+                    retrieve_single_present_value(val, m);
+            }
+            
+            template <typename T> void retrieve_single_present_value(T* val, PBMeta meta);
+            template <typename T> void retrieve_repeated_value(T* val, int index, PBMeta meta);
+            
+            struct MessageCollection
+            {
+            MessageCollection(const std::string& n) : name(n) { }
                 std::string name;
 
                 // time -> Message contents
@@ -64,18 +88,18 @@ namespace goby
                 void add_message(const goby::common::HDF5ProtobufEntry& entry)
                     {
                         const std::string& msg_name = entry.msg->GetDescriptor()->full_name();
-                        typedef std::map<std::string, Message>::iterator It;
+                        typedef std::map<std::string, MessageCollection>::iterator It;
                         It it = entries.find(msg_name);
                         if(it == entries.end())
                         {
-                            std::pair<It, bool> itpair = entries.insert(std::make_pair(msg_name, Message(msg_name)));
+                            std::pair<It, bool> itpair = entries.insert(std::make_pair(msg_name, MessageCollection(msg_name)));
                             it = itpair.first;
                         }
                         it->second.entries.insert(std::make_pair(entry.time, entry.msg));
                     }
     
                 // message name -> hdf5::Message
-                std::map<std::string, Message> entries;
+                std::map<std::string, MessageCollection> entries;
             };
 
             // keeps track of HDF5 groups for us, and creates them as needed
@@ -149,28 +173,54 @@ namespace goby
                 void collect();
                 void write();
                 void write_channel(const std::string& group, const goby::common::hdf5::Channel& channel);
-                void write_message(const std::string& group, const goby::common::hdf5::Message& message);
-                void write_time(const std::string& group, const goby::common::hdf5::Message& message);
+                void write_message_collection(const std::string& group, const goby::common::hdf5::MessageCollection& message_collection);
+                void write_time(const std::string& group, const goby::common::hdf5::MessageCollection& message_collection);
 
+                void write_field_selector(const std::string& group, const google::protobuf::FieldDescriptor* field_desc, const std::vector<const google::protobuf::Message* >& messages);
 
                 template<typename T>
-                    void write_field(const std::string& group, const google::protobuf::FieldDescriptor* field_desc, const goby::common::hdf5::Message& message)
+                    void write_field(const std::string& group, const google::protobuf::FieldDescriptor* field_desc, const std::vector<const google::protobuf::Message* >& messages)
                 {
-                    std::vector<T> values(message.entries.size(), 0);
-                    int i = 0;
-                    for(std::multimap<goby::uint64, boost::shared_ptr<google::protobuf::Message> >::const_iterator it = message.entries.begin(), end = message.entries.end(); it != end; ++it)
+                    if(field_desc->is_repeated())
                     {
-                        const google::protobuf::Reflection* refl = it->second->GetReflection();
-                        
-                        if(field_desc->is_repeated())
-                            continue; // TODO: support repeateds
-                        else
-                            retrieve_single_value<T>(&values[i], refl, field_desc, *it->second);
-                        
-                        ++i;
+                        std::vector<std::vector<T> > values(messages.size(), std::vector<T>());
+                    
+                        int i = 0;
+                        int max_field_size = 0;
+                        for(std::vector<const google::protobuf::Message* >::const_iterator it = messages.begin(), end = messages.end(); it != end; ++it)
+                        {
+                            const google::protobuf::Reflection* refl = (*it)->GetReflection();
+                            std::vector<T>& v_row = values[i];
+                            int field_size = refl->FieldSize(**it, field_desc);
+                            if(field_size > max_field_size) max_field_size = field_size;
+                            v_row.resize(field_size);
+
+                            for(int j = 0; j < field_size; ++j)
+                                retrieve_repeated_value<T>(&v_row[j], j, PBMeta(refl, field_desc, (**it)));
+                            ++i;
+                        }
+                        write_matrix(group, field_desc->name(), values, max_field_size);
                     }
-                    write_vector(group, field_desc->name(), values);
+                    else
+                    {
+                        std::vector<T> values(messages.size(), T());
+                    
+                        int i = 0;
+                        for(std::vector<const google::protobuf::Message* >::const_iterator it = messages.begin(), end = messages.end(); it != end; ++it)
+                        {
+                            const google::protobuf::Reflection* refl = (*it)->GetReflection();
+                            retrieve_single_value<T>(&values[i], PBMeta(refl, field_desc, (**it)));
+                            ++i;
+                        }
+                        write_vector(group, field_desc->name(), values);
+                    }
                 }
+
+                
+                void write_embedded_message(const std::string& group, const google::protobuf::FieldDescriptor* field_desc, const std::vector<const google::protobuf::Message*> messages);
+
+                
+
                 
                 template<typename T>
                     void write_vector(const std::string& group, const std::string dataset_name, const std::vector<T>& data)
@@ -182,7 +232,70 @@ namespace goby
                     H5::DataSet dataset = grp.createDataSet(dataset_name,
                                                             predicate<T>(),
                                                             dataspace);
-                    dataset.write(&data[0], predicate<T>());
+                    if(data.size())
+                        dataset.write(&data[0], predicate<T>());
+                }
+
+
+                template<typename T>
+                    void write_matrix(const std::string& group, const std::string dataset_name, const std::vector<std::vector<T> >& data, int max_field_size)
+                {
+                    hsize_t nx = data.size(), ny = max_field_size;
+                    const int rank = 2;
+                    hsize_t dimsf[] = { nx, ny };
+
+                    T cdata[nx][ny];
+                    for(int i = 0; i < nx; ++i)
+                    {
+                        const std::vector<T>& inner = data[i];
+                        for(int j = 0; j < ny; ++j)
+                        {
+                            if(j < inner.size())
+                                cdata[i][j] = data[i][j];
+                            else
+                                retrieve_empty_value(&cdata[i][j]);
+                        }
+                    }
+                    
+                    H5::DataSpace dataspace(rank, dimsf, dimsf);
+                    H5::Group& grp = group_factory_.fetch_group(group);
+
+                    H5::DataSet dataset = grp.createDataSet(dataset_name,
+                                                            predicate<T>(),
+                                                            dataspace);
+                    dataset.write(cdata, predicate<T>());
+                }
+
+                
+                
+                void write_vector(const std::string& group,
+                                  const std::string dataset_name,
+                                  const std::vector<std::string>& data)
+                {                   
+                    std::vector<const char*> data_c_str;
+                    for (unsigned i = 0, n = data.size(); i < n; ++i) 
+                        data_c_str.push_back(data[i].c_str());
+                    
+                    const int rank = 1;
+                    hsize_t dimsf[] = {data.size()}; 
+                    H5::DataSpace dataspace(rank, dimsf, dimsf);
+                    H5::StrType datatype(H5::PredType::C_S1, H5T_VARIABLE);          
+                    H5::Group& grp = group_factory_.fetch_group(group);
+                    H5::DataSet dataset = grp.createDataSet(dataset_name,
+                                                            datatype,
+                                                            dataspace);
+
+                    if(data_c_str.size())
+                        dataset.write(data_c_str.data(), datatype);
+                }
+                
+
+                void write_matrix(const std::string& group,
+                                  const std::string dataset_name,
+                                  const std::vector<std::vector<std::string > >& data,
+                                  int max_field_size)
+                {                   
+                    // TODO: implement if this makes sense
                 }
                 
                 
@@ -199,81 +312,104 @@ namespace goby
                 goby::common::hdf5::GroupFactory group_factory_;
             };
 
+            template <>
+                void retrieve_empty_value(goby::int32* val)
+            { *val = std::numeric_limits<goby::int32>::max(); }
+            template <>
+                void retrieve_single_present_value(goby::int32* val, PBMeta m)
+            { *val = m.refl->GetInt32(m.msg, m.field_desc); }
+            template <>
+                void retrieve_repeated_value(goby::int32* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedInt32(m.msg, m.field_desc, index); }
+
+            template <>
+                void retrieve_empty_value(goby::uint32* val)
+            { *val = std::numeric_limits<goby::uint32>::max(); }
+            template <>
+                void retrieve_single_present_value(goby::uint32* val, PBMeta m)
+            { *val = m.refl->GetUInt32(m.msg, m.field_desc); }
+            template <>
+                void retrieve_repeated_value(goby::uint32* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedUInt32(m.msg, m.field_desc, index); }
+
+            template <>
+                void retrieve_empty_value(goby::int64* val)
+            { *val = std::numeric_limits<goby::int64>::max(); }
+            template <>
+                void retrieve_single_present_value(goby::int64* val, PBMeta m)
+            { *val = m.refl->GetInt64(m.msg, m.field_desc); }
+            template <>
+                void retrieve_repeated_value(goby::int64* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedInt64(m.msg, m.field_desc, index); }
 
 
             template <>
-                void retrieve_single_value(goby::int32* val,
-                                           const google::protobuf::Reflection* refl,
-                                           const google::protobuf::FieldDescriptor* field_desc,
-                                           const google::protobuf::Message& msg)
-            {
-                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
-                    *val = std::numeric_limits<goby::int32>::max();
-                else
-                    *val = refl->GetInt32(msg, field_desc);
-            }
-
+                void retrieve_empty_value(goby::uint64* val)
+            { *val = std::numeric_limits<goby::uint64>::max(); }
             template <>
-                void retrieve_single_value(goby::uint32* val,
-                                           const google::protobuf::Reflection* refl,
-                                           const google::protobuf::FieldDescriptor* field_desc,
-                                           const google::protobuf::Message& msg)
-            {
-                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
-                    *val = std::numeric_limits<goby::uint32>::max();
-                else
-                    *val = refl->GetUInt32(msg, field_desc);
-            }
-
+                void retrieve_single_present_value(goby::uint64* val, PBMeta m)
+            { *val = m.refl->GetUInt64(m.msg, m.field_desc); }
             template <>
-                void retrieve_single_value(goby::int64* val,
-                                           const google::protobuf::Reflection* refl,
-                                           const google::protobuf::FieldDescriptor* field_desc,
-                                           const google::protobuf::Message& msg)
-            {
-                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
-                    *val = std::numeric_limits<goby::int64>::max();
-                else
-                    *val = refl->GetInt64(msg, field_desc);
-            }
+                void retrieve_repeated_value(goby::uint64* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedUInt64(m.msg, m.field_desc, index); }
 
 
             template <>
-                void retrieve_single_value(goby::uint64* val,
-                                           const google::protobuf::Reflection* refl,
-                                           const google::protobuf::FieldDescriptor* field_desc,
-                                           const google::protobuf::Message& msg)
+                void retrieve_empty_value(double* val)
+            { *val = std::numeric_limits<double>::quiet_NaN(); }
+            template <>
+                void retrieve_single_present_value(double* val, PBMeta m)
+            { *val = m.refl->GetDouble(m.msg, m.field_desc); }
+            template <>
+                void retrieve_repeated_value(double* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedDouble(m.msg, m.field_desc, index); }
+
+            template <>
+                void retrieve_empty_value(float* val)
+            { *val = std::numeric_limits<float>::quiet_NaN(); }
+            template <>
+                void retrieve_single_present_value(float* val, PBMeta m)
+            { *val = m.refl->GetFloat(m.msg, m.field_desc); }
+            template <>
+                void retrieve_repeated_value(float* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedFloat(m.msg, m.field_desc, index); }
+
+
+            // used for bool
+            template <>
+                void retrieve_empty_value(unsigned char* val)
+            { *val = std::numeric_limits<unsigned char>::max(); }
+            template <>
+                void retrieve_single_present_value(unsigned char* val, PBMeta m)
             {
-                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
-                    *val = std::numeric_limits<goby::uint64>::max();
-                else
-                    *val = refl->GetUInt64(msg, field_desc);
+                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_BOOL)
+                    *val = m.refl->GetBool(m.msg, m.field_desc);
+            }
+            template <>
+                void retrieve_repeated_value(unsigned char* val, int index, PBMeta m)
+            {
+                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_BOOL)
+                    *val = m.refl->GetRepeatedBool(m.msg, m.field_desc, index);
             }
 
 
             template <>
-                void retrieve_single_value(double* val,
-                                           const google::protobuf::Reflection* refl,
-                                           const google::protobuf::FieldDescriptor* field_desc,
-                                           const google::protobuf::Message& msg)
+                void retrieve_empty_value(std::string* val)
+            { val->clear(); }
+            template <>
+                void retrieve_single_value(std::string* val, PBMeta m)
             {
-                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
-                    *val = std::numeric_limits<double>::quiet_NaN();
-                else
-                    *val = refl->GetDouble(msg, field_desc);
+                    *val = m.refl->GetString(m.msg, m.field_desc);
+                    if(m.field_desc->type() == google::protobuf::FieldDescriptor::TYPE_BYTES)
+                        *val = goby::util::hex_encode(*val);                
+            }
+            template <>
+                void retrieve_repeated_value(std::string* val, int index, PBMeta m)
+            {
+                // TODO: implement if this makes sense
             }
 
-            template <>
-                void retrieve_single_value(float* val,
-                                           const google::protobuf::Reflection* refl,
-                                           const google::protobuf::FieldDescriptor* field_desc,
-                                           const google::protobuf::Message& msg)
-            {
-                if(field_desc->is_optional() && !refl->HasField(msg, field_desc))
-                    *val = std::numeric_limits<float>::quiet_NaN();
-                else
-                    *val = refl->GetFloat(msg, field_desc);
-            }
+            
         }
     }
 }

--- a/src/apps/common/goby_hdf5/hdf5.h
+++ b/src/apps/common/goby_hdf5/hdf5.h
@@ -31,53 +31,16 @@
 #include "goby/common/protobuf/hdf5.pb.h"
 #include "goby/util/binary.h"
 
+#include "hdf5_predicate.h"
+#include "hdf5_protobuf_values.h"
+
 namespace goby
 {
     namespace common
     {
         namespace hdf5
         {
-            template <typename T> H5::PredType predicate();
-            template<> H5::PredType predicate<goby::int32>() { return H5::PredType::NATIVE_INT32; }
-            template<> H5::PredType predicate<goby::int64>() { return H5::PredType::NATIVE_INT64; }
-            template<> H5::PredType predicate<goby::uint32>() { return H5::PredType::NATIVE_UINT32; }
-            template<> H5::PredType predicate<goby::uint64>() { return H5::PredType::NATIVE_UINT64; }
-            template<> H5::PredType predicate<float>() { return H5::PredType::NATIVE_FLOAT; }
-            template<> H5::PredType predicate<double>() { return H5::PredType::NATIVE_DOUBLE; }
-            template<> H5::PredType predicate<unsigned char>() { return H5::PredType::NATIVE_UCHAR; }
  
-            struct PBMeta
-            {
-                PBMeta(const google::protobuf::Reflection* r,
-                       const google::protobuf::FieldDescriptor* f,
-                       const google::protobuf::Message& m) : refl(r), field_desc(f), msg(m)
-                    { }
-                
-                const google::protobuf::Reflection* refl;
-                const google::protobuf::FieldDescriptor* field_desc;
-                const google::protobuf::Message& msg;
-            };
-            
-            template <typename T> void retrieve_empty_value(T* val);
-            template <typename T> T retrieve_empty_value()
-            {
-                T t;
-                retrieve_empty_value(&t);
-                return t;
-            }
-            
-            
-            template <typename T> void retrieve_single_value(T* val, PBMeta m)
-            {
-                if(m.field_desc->is_optional() && !m.refl->HasField(m.msg, m.field_desc))
-                    retrieve_empty_value(val);
-                else
-                    retrieve_single_present_value(val, m);
-            }
-            
-            template <typename T> void retrieve_single_present_value(T* val, PBMeta meta);
-            template <typename T> void retrieve_repeated_value(T* val, int index, PBMeta meta);
-            
             struct MessageCollection
             {
             MessageCollection(const std::string& n) : name(n) { }
@@ -86,25 +49,13 @@ namespace goby
                 // time -> Message contents
                 std::multimap<goby::uint64, boost::shared_ptr<google::protobuf::Message> > entries;
             };
-    
 
             struct Channel
             {
             Channel(const std::string& n) : name(n) { }
                 std::string name;
 
-                void add_message(const goby::common::HDF5ProtobufEntry& entry)
-                    {
-                        const std::string& msg_name = entry.msg->GetDescriptor()->full_name();
-                        typedef std::map<std::string, MessageCollection>::iterator It;
-                        It it = entries.find(msg_name);
-                        if(it == entries.end())
-                        {
-                            std::pair<It, bool> itpair = entries.insert(std::make_pair(msg_name, MessageCollection(msg_name)));
-                            it = itpair.first;
-                        }
-                        it->second.entries.insert(std::make_pair(entry.time, entry.msg));
-                    }
+                void add_message(const goby::common::HDF5ProtobufEntry& entry);
     
                 // message name -> hdf5::Message
                 std::map<std::string, MessageCollection> entries;
@@ -116,17 +67,10 @@ namespace goby
             public:
             GroupFactory(H5::H5File& h5file) :
                 root_group_(h5file.openGroup("/"))
-                {
-                }
+                {  }
 
                 // creates or opens group
-                H5::Group& fetch_group(const std::string& group_path)
-                {
-                    std::deque<std::string> nodes;
-                    std::string clean_path = boost::trim_copy_if(group_path, boost::algorithm::is_space() || boost::algorithm::is_any_of("/"));
-                    boost::split(nodes, clean_path, boost::is_any_of("/"));
-                    return root_group_.fetch_group(nodes);
-                }
+                H5::Group& fetch_group(const std::string& group_path);
     
     
             private:
@@ -134,36 +78,15 @@ namespace goby
                 {
                 public:
                     // for root group (already exists)
-                GroupWrapper(H5::Group group) : group_(group)
-                    { }
+                GroupWrapper(H5::Group group) : group_(group) { }
 
                     // for children groups
-                    GroupWrapper(const std::string& name, H5::Group& parent)
-                    {
-                        group_ = parent.createGroup(name);
-                    }
+                GroupWrapper(const std::string& name, H5::Group& parent)
+                    : group_(parent.createGroup(name)) { }
+                    
 
-                    H5::Group& fetch_group(std::deque<std::string>& nodes)
-                    {
-                        if(nodes.empty())
-                        {
-                            return group_;
-                        }
-                        else
-                        {
-                            typedef std::map<std::string, GroupWrapper>::iterator It;
-                            It it = children_.find(nodes[0]);
-                            if(it == children_.end())
-                            {
-                                std::pair<It, bool> itpair = children_.insert(std::make_pair(nodes[0], GroupWrapper(nodes[0], group_)));
-                                it = itpair.first;
-                            }
-                            nodes.pop_front();
-                            return it->second.fetch_group(nodes); 
-                        }
-                    }
-        
-        
+                    H5::Group& fetch_group(std::deque<std::string>& nodes);
+                    
                 private:
                     H5::Group group_;
                     std::map<std::string, GroupWrapper> children_;
@@ -194,103 +117,18 @@ namespace goby
                 template<typename T>
                     void write_field(const std::string& group, const google::protobuf::FieldDescriptor* field_desc,
                                      const std::vector<const google::protobuf::Message* >& messages,
-                                     std::vector<hsize_t>& hs)
-                {
-                    if(field_desc->is_repeated())
-                    {
-                        // pass one to figure out field size
-                        int max_field_size = 0;
-                        for(unsigned i = 0, n = messages.size(); i < n; ++i)
-                        {
-                            if(messages[i])
-                            {
-                                const google::protobuf::Reflection* refl = messages[i]->GetReflection();
-                                int field_size = refl->FieldSize(*messages[i], field_desc);
-                                if(field_size > max_field_size) max_field_size = field_size;
-                            }
-                        }
-
-                        hs.push_back(max_field_size);
-
-                        for(int i = 0; i < hs.size(); ++i)
-                            std::cout << field_desc->name() << ": write_field: hs[" << i << "]: " << hs[i] << std::endl;
-
-                        std::vector<T> values(messages.size()*max_field_size, retrieve_empty_value<T>());
-
-                        for(unsigned i = 0, n = messages.size(); i < n; ++i)
-                        {
-                            if(messages[i])
-                            {
-                                const google::protobuf::Reflection* refl = messages[i]->GetReflection();
-                                int field_size = refl->FieldSize(*messages[i], field_desc);
-                                for(int j = 0; j < field_size; ++j)
-                                    retrieve_repeated_value<T>(&values[i*max_field_size+j], j, PBMeta(refl, field_desc, (*messages[i])));
-                            }
-                        }
-
-                        write_vector(group, field_desc->name(), values, hs);
-
-                        hs.pop_back();
-                    }
-                    else
-                    {
-                        std::vector<T> values(messages.size(), retrieve_empty_value<T>());
-                        for(unsigned i = 0, n = messages.size(); i < n; ++i)
-                        {
-                            if(messages[i])
-                            {
-                                const google::protobuf::Reflection* refl = messages[i]->GetReflection();
-                                retrieve_single_value<T>(&values[i], PBMeta(refl, field_desc, (*messages[i])));
-                            }
-                        }
-
-                        write_vector(group, field_desc->name(), values, hs);
-                    }
-                }
-
+                                     std::vector<hsize_t>& hs);
                 
                 void write_embedded_message(const std::string& group, const google::protobuf::FieldDescriptor* field_desc, const std::vector<const google::protobuf::Message*> messages, std::vector<hsize_t>& hs);
-
-
                 
                 template<typename T>
-                    void write_vector(const std::string& group, const std::string dataset_name, const std::vector<T>& data, const std::vector<hsize_t>& hs)
-                {
-                    
-                        for(int i = 0; i < hs.size(); ++i)
-                            std::cout << group << "/" << dataset_name << ": write_vector: hs[" << i << "]: " << hs[i] << std::endl;
-
-                    
-                    H5::DataSpace dataspace(hs.size(), hs.data(), hs.data());
-                    H5::Group& grp = group_factory_.fetch_group(group);
-                    H5::DataSet dataset = grp.createDataSet(dataset_name,
-                                                            predicate<T>(),
-                                                            dataspace);
-                    if(data.size())
-                        dataset.write(&data[0], predicate<T>());
-                }                
+                    void write_vector(const std::string& group, const std::string dataset_name, const std::vector<T>& data, const std::vector<hsize_t>& hs);
                 
                 void write_vector(const std::string& group,
                                   const std::string dataset_name,
                                   const std::vector<std::string>& data,
-                                  const std::vector<hsize_t>& hs)
-            {                   
-                    std::vector<const char*> data_c_str;
-                    for (unsigned i = 0, n = data.size(); i < n; ++i) 
-                        data_c_str.push_back(data[i].c_str());
+                                  const std::vector<hsize_t>& hs);
 
-                    
-                    H5::DataSpace dataspace(hs.size(), hs.data(), hs.data());
-                    H5::StrType datatype(H5::PredType::C_S1, H5T_VARIABLE);          
-                    H5::Group& grp = group_factory_.fetch_group(group);
-                    H5::DataSet dataset = grp.createDataSet(dataset_name,
-                                                            datatype,
-                                                            dataspace);
-
-                    if(data_c_str.size())
-                        dataset.write(data_c_str.data(), datatype);
-                }
-                
                 void iterate() { }
 
             private:
@@ -304,128 +142,71 @@ namespace goby
                 goby::common::hdf5::GroupFactory group_factory_;
             };
 
-            template <>
-                void retrieve_empty_value(goby::int32* val)
-            { *val = std::numeric_limits<goby::int32>::max(); }
-            template <>
-                void retrieve_single_present_value(goby::int32* val, PBMeta m)
+            template<typename T>
+                void Writer::write_field(const std::string& group, const google::protobuf::FieldDescriptor* field_desc, const std::vector<const google::protobuf::Message* >& messages, std::vector<hsize_t>& hs)
             {
-                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_INT32)
+                if(field_desc->is_repeated())
                 {
-                    *val = m.refl->GetInt32(m.msg, m.field_desc);
+                    // pass one to figure out field size
+                    int max_field_size = 0;
+                    for(unsigned i = 0, n = messages.size(); i < n; ++i)
+                    {
+                        if(messages[i])
+                        {
+                            const google::protobuf::Reflection* refl = messages[i]->GetReflection();
+                            int field_size = refl->FieldSize(*messages[i], field_desc);
+                            if(field_size > max_field_size) max_field_size = field_size;
+                        }
+                    }
+
+                    hs.push_back(max_field_size);
+
+                    std::vector<T> values(messages.size()*max_field_size, retrieve_empty_value<T>());
+
+                    for(unsigned i = 0, n = messages.size(); i < n; ++i)
+                    {
+                        if(messages[i])
+                        {
+                            const google::protobuf::Reflection* refl = messages[i]->GetReflection();
+                            int field_size = refl->FieldSize(*messages[i], field_desc);
+                            for(int j = 0; j < field_size; ++j)
+                                retrieve_repeated_value<T>(&values[i*max_field_size+j], j, PBMeta(refl, field_desc, (*messages[i])));
+                        }
+                    }
+
+                    write_vector(group, field_desc->name(), values, hs);
+
+                    hs.pop_back();
                 }
-                else if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_ENUM)
+                else
                 {
-                    const google::protobuf::EnumValueDescriptor* enum_desc =
-                        m.refl->GetEnum(m.msg, m.field_desc);
-                    *val = enum_desc->number();
+                    std::vector<T> values(messages.size(), retrieve_empty_value<T>());
+                    for(unsigned i = 0, n = messages.size(); i < n; ++i)
+                    {
+                        if(messages[i])
+                        {
+                            const google::protobuf::Reflection* refl = messages[i]->GetReflection();
+                            retrieve_single_value<T>(&values[i], PBMeta(refl, field_desc, (*messages[i])));
+                        }
+                    }
+
+                    write_vector(group, field_desc->name(), values, hs);
                 }
             }
-            template <>
-                void retrieve_repeated_value(goby::int32* val, int index, PBMeta m)
+
+            template<typename T>
+                void Writer::write_vector(const std::string& group, const std::string dataset_name, const std::vector<T>& data, const std::vector<hsize_t>& hs)
             {
-                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_INT32)
-                {
-                    *val = m.refl->GetRepeatedInt32(m.msg, m.field_desc, index);
-                }
-                else if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_ENUM)
-                {
-                    const google::protobuf::EnumValueDescriptor* enum_desc =
-                        m.refl->GetRepeatedEnum(m.msg, m.field_desc, index);
-                    *val = enum_desc->number();                    
-                }                
-            }
+                    
+                H5::DataSpace dataspace(hs.size(), hs.data(), hs.data());
+                H5::Group& grp = group_factory_.fetch_group(group);
+                H5::DataSet dataset = grp.createDataSet(dataset_name,
+                                                        predicate<T>(),
+                                                        dataspace);
+                if(data.size())
+                    dataset.write(&data[0], predicate<T>());
+            }                
 
-            template <>
-                void retrieve_empty_value(goby::uint32* val)
-            { *val = std::numeric_limits<goby::uint32>::max(); }
-            template <>
-                void retrieve_single_present_value(goby::uint32* val, PBMeta m)
-            { *val = m.refl->GetUInt32(m.msg, m.field_desc); }
-            template <>
-                void retrieve_repeated_value(goby::uint32* val, int index, PBMeta m)
-            { *val = m.refl->GetRepeatedUInt32(m.msg, m.field_desc, index); }
-
-            template <>
-                void retrieve_empty_value(goby::int64* val)
-            { *val = std::numeric_limits<goby::int64>::max(); }
-            template <>
-                void retrieve_single_present_value(goby::int64* val, PBMeta m)
-            { *val = m.refl->GetInt64(m.msg, m.field_desc); }
-            template <>
-                void retrieve_repeated_value(goby::int64* val, int index, PBMeta m)
-            { *val = m.refl->GetRepeatedInt64(m.msg, m.field_desc, index); }
-
-
-            template <>
-                void retrieve_empty_value(goby::uint64* val)
-            { *val = std::numeric_limits<goby::uint64>::max(); }
-            template <>
-                void retrieve_single_present_value(goby::uint64* val, PBMeta m)
-            { *val = m.refl->GetUInt64(m.msg, m.field_desc); }
-            template <>
-                void retrieve_repeated_value(goby::uint64* val, int index, PBMeta m)
-            { *val = m.refl->GetRepeatedUInt64(m.msg, m.field_desc, index); }
-
-
-            template <>
-                void retrieve_empty_value(double* val)
-            { *val = std::numeric_limits<double>::quiet_NaN(); }
-            template <>
-                void retrieve_single_present_value(double* val, PBMeta m)
-            { *val = m.refl->GetDouble(m.msg, m.field_desc); }
-            template <>
-                void retrieve_repeated_value(double* val, int index, PBMeta m)
-            { *val = m.refl->GetRepeatedDouble(m.msg, m.field_desc, index); }
-
-            template <>
-                void retrieve_empty_value(float* val)
-            { *val = std::numeric_limits<float>::quiet_NaN(); }
-            template <>
-                void retrieve_single_present_value(float* val, PBMeta m)
-            { *val = m.refl->GetFloat(m.msg, m.field_desc); }
-            template <>
-                void retrieve_repeated_value(float* val, int index, PBMeta m)
-            { *val = m.refl->GetRepeatedFloat(m.msg, m.field_desc, index); }
-
-
-            // used for bool
-            template <>
-                void retrieve_empty_value(unsigned char* val)
-            { *val = std::numeric_limits<unsigned char>::max(); }
-            template <>
-                void retrieve_single_present_value(unsigned char* val, PBMeta m)
-            {
-                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_BOOL)
-                    *val = m.refl->GetBool(m.msg, m.field_desc);
-            }
-            template <>
-                void retrieve_repeated_value(unsigned char* val, int index, PBMeta m)
-            {
-                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_BOOL)
-                    *val = m.refl->GetRepeatedBool(m.msg, m.field_desc, index);
-            }
-
-
-            template <>
-                void retrieve_empty_value(std::string* val)
-            { val->clear(); }
-            template <>
-                void retrieve_single_value(std::string* val, PBMeta m)
-            {
-                *val = m.refl->GetString(m.msg, m.field_desc);
-                if(m.field_desc->type() == google::protobuf::FieldDescriptor::TYPE_BYTES)
-                    *val = goby::util::hex_encode(*val);                
-            }
-            template <>
-                void retrieve_repeated_value(std::string* val, int index, PBMeta m)
-            {
-                *val = m.refl->GetRepeatedString(m.msg, m.field_desc, index);
-                if(m.field_desc->type() == google::protobuf::FieldDescriptor::TYPE_BYTES)
-                    *val = goby::util::hex_encode(*val);
-            }
-
-            
         }
     }
 }

--- a/src/apps/common/goby_hdf5/hdf5_predicate.h
+++ b/src/apps/common/goby_hdf5/hdf5_predicate.h
@@ -1,0 +1,48 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (2013-)
+//                     Massachusetts Institute of Technology (2007-2014)
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Binaries
+// ("The Goby Binaries").
+//
+// The Goby Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Goby Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef GOBYHDFPREDICATE520160525H
+#define GOBYHDFPREDICATE520160525H
+
+#include "H5Cpp.h"
+
+#include "goby/util/primitive_types.h"
+
+namespace goby
+{
+    namespace common
+    {
+        namespace hdf5
+        {
+            template <typename T> H5::PredType predicate();
+            template<> H5::PredType predicate<goby::int32>() { return H5::PredType::NATIVE_INT32; }
+            template<> H5::PredType predicate<goby::int64>() { return H5::PredType::NATIVE_INT64; }
+            template<> H5::PredType predicate<goby::uint32>() { return H5::PredType::NATIVE_UINT32; }
+            template<> H5::PredType predicate<goby::uint64>() { return H5::PredType::NATIVE_UINT64; }
+            template<> H5::PredType predicate<float>() { return H5::PredType::NATIVE_FLOAT; }
+            template<> H5::PredType predicate<double>() { return H5::PredType::NATIVE_DOUBLE; }
+            template<> H5::PredType predicate<unsigned char>() { return H5::PredType::NATIVE_UCHAR; }
+        }
+    }
+}
+
+
+#endif

--- a/src/apps/common/goby_hdf5/hdf5_protobuf_values.h
+++ b/src/apps/common/goby_hdf5/hdf5_protobuf_values.h
@@ -1,0 +1,197 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (2013-)
+//                     Massachusetts Institute of Technology (2007-2014)
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Binaries
+// ("The Goby Binaries").
+//
+// The Goby Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Goby Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef GOBYHDF5PROTOBUFVALUES20160525H
+#define GOBYHDF5PROTOBUFVALUES20160525H
+
+
+#include <google/protobuf/message.h>
+#include <google/protobuf/descriptor.h>
+
+namespace goby
+{
+    namespace common
+    {
+        namespace hdf5
+        {
+
+            
+            struct PBMeta
+            {
+                PBMeta(const google::protobuf::Reflection* r,
+                       const google::protobuf::FieldDescriptor* f,
+                       const google::protobuf::Message& m) : refl(r), field_desc(f), msg(m)
+                    { }
+                
+                const google::protobuf::Reflection* refl;
+                const google::protobuf::FieldDescriptor* field_desc;
+                const google::protobuf::Message& msg;
+            };
+
+            
+            template <typename T> void retrieve_empty_value(T* val);
+            template <typename T> T retrieve_empty_value()
+            {
+                T t;
+                retrieve_empty_value(&t);
+                return t;
+            }
+            
+            
+            template <typename T> void retrieve_single_value(T* val, PBMeta m)
+            {
+                if(m.field_desc->is_optional() && !m.refl->HasField(m.msg, m.field_desc))
+                    retrieve_empty_value(val);
+                else
+                    retrieve_single_present_value(val, m);
+            }
+            
+            template <typename T> void retrieve_single_present_value(T* val, PBMeta meta);
+            template <typename T> void retrieve_repeated_value(T* val, int index, PBMeta meta);
+
+            template <>
+                void retrieve_empty_value(goby::int32* val)
+            { *val = std::numeric_limits<goby::int32>::max(); }
+            template <>
+                void retrieve_single_present_value(goby::int32* val, PBMeta m)
+            {
+                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_INT32)
+                {
+                    *val = m.refl->GetInt32(m.msg, m.field_desc);
+                }
+                else if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_ENUM)
+                {
+                    const google::protobuf::EnumValueDescriptor* enum_desc =
+                        m.refl->GetEnum(m.msg, m.field_desc);
+                    *val = enum_desc->number();
+                }
+            }
+            template <>
+                void retrieve_repeated_value(goby::int32* val, int index, PBMeta m)
+            {
+                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_INT32)
+                {
+                    *val = m.refl->GetRepeatedInt32(m.msg, m.field_desc, index);
+                }
+                else if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_ENUM)
+                {
+                    const google::protobuf::EnumValueDescriptor* enum_desc =
+                        m.refl->GetRepeatedEnum(m.msg, m.field_desc, index);
+                    *val = enum_desc->number();                    
+                }                
+            }
+
+            template <>
+                void retrieve_empty_value(goby::uint32* val)
+            { *val = std::numeric_limits<goby::uint32>::max(); }
+            template <>
+                void retrieve_single_present_value(goby::uint32* val, PBMeta m)
+            { *val = m.refl->GetUInt32(m.msg, m.field_desc); }
+            template <>
+                void retrieve_repeated_value(goby::uint32* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedUInt32(m.msg, m.field_desc, index); }
+
+            template <>
+                void retrieve_empty_value(goby::int64* val)
+            { *val = std::numeric_limits<goby::int64>::max(); }
+            template <>
+                void retrieve_single_present_value(goby::int64* val, PBMeta m)
+            { *val = m.refl->GetInt64(m.msg, m.field_desc); }
+            template <>
+                void retrieve_repeated_value(goby::int64* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedInt64(m.msg, m.field_desc, index); }
+
+
+            template <>
+                void retrieve_empty_value(goby::uint64* val)
+            { *val = std::numeric_limits<goby::uint64>::max(); }
+            template <>
+                void retrieve_single_present_value(goby::uint64* val, PBMeta m)
+            { *val = m.refl->GetUInt64(m.msg, m.field_desc); }
+            template <>
+                void retrieve_repeated_value(goby::uint64* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedUInt64(m.msg, m.field_desc, index); }
+
+
+            template <>
+                void retrieve_empty_value(double* val)
+            { *val = std::numeric_limits<double>::quiet_NaN(); }
+            template <>
+                void retrieve_single_present_value(double* val, PBMeta m)
+            { *val = m.refl->GetDouble(m.msg, m.field_desc); }
+            template <>
+                void retrieve_repeated_value(double* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedDouble(m.msg, m.field_desc, index); }
+
+            template <>
+                void retrieve_empty_value(float* val)
+            { *val = std::numeric_limits<float>::quiet_NaN(); }
+            template <>
+                void retrieve_single_present_value(float* val, PBMeta m)
+            { *val = m.refl->GetFloat(m.msg, m.field_desc); }
+            template <>
+                void retrieve_repeated_value(float* val, int index, PBMeta m)
+            { *val = m.refl->GetRepeatedFloat(m.msg, m.field_desc, index); }
+
+
+            // used for bool
+            template <>
+                void retrieve_empty_value(unsigned char* val)
+            { *val = std::numeric_limits<unsigned char>::max(); }
+            template <>
+                void retrieve_single_present_value(unsigned char* val, PBMeta m)
+            {
+                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_BOOL)
+                    *val = m.refl->GetBool(m.msg, m.field_desc);
+            }
+            template <>
+                void retrieve_repeated_value(unsigned char* val, int index, PBMeta m)
+            {
+                if(m.field_desc->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_BOOL)
+                    *val = m.refl->GetRepeatedBool(m.msg, m.field_desc, index);
+            }
+
+
+            template <>
+                void retrieve_empty_value(std::string* val)
+            { val->clear(); }
+            template <>
+                void retrieve_single_value(std::string* val, PBMeta m)
+            {
+                *val = m.refl->GetString(m.msg, m.field_desc);
+                if(m.field_desc->type() == google::protobuf::FieldDescriptor::TYPE_BYTES)
+                    *val = goby::util::hex_encode(*val);                
+            }
+            template <>
+                void retrieve_repeated_value(std::string* val, int index, PBMeta m)
+            {
+                *val = m.refl->GetRepeatedString(m.msg, m.field_desc, index);
+                if(m.field_desc->type() == google::protobuf::FieldDescriptor::TYPE_BYTES)
+                    *val = goby::util::hex_encode(*val);
+            }
+            
+        }
+    }
+}
+
+
+
+#endif

--- a/src/common/configuration_reader.cpp
+++ b/src/common/configuration_reader.cpp
@@ -339,7 +339,7 @@ void goby::common::ConfigReader::get_example_cfg_file(google::protobuf::Message*
 }
 
 
-void  goby::common::ConfigReader::get_protobuf_program_options(boost::program_options::options_description& po_desc,
+void goby::common::ConfigReader::get_protobuf_program_options(boost::program_options::options_description& po_desc,
                                                              const google::protobuf::Descriptor* desc)
 {
     for(int i = 0, n = desc->field_count(); i < n; ++i)

--- a/src/common/hdf5_plugin.h
+++ b/src/common/hdf5_plugin.h
@@ -1,0 +1,79 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (2013-)
+//                     Massachusetts Institute of Technology (2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef HDF5_PLUGIN20160523H
+#define HDF5_PLUGIN20160523H
+
+#include <google/protobuf/message.h>
+
+#include <boost/shared_ptr.hpp>
+
+#include "goby/util/primitive_types.h"
+#include "goby/common/protobuf/hdf5.pb.h"
+
+namespace goby
+{
+    namespace common
+    {
+        struct HDF5ProtobufEntry
+        {
+            std::string channel;
+            goby::uint64 time;
+            boost::shared_ptr<google::protobuf::Message> msg;
+
+        HDF5ProtobufEntry() : time(0) { }
+            
+            void clear()
+                {
+                    channel.clear();
+                    time = 0;
+                    msg.reset();
+                }
+        };
+        
+        inline std::ostream& operator<<(std::ostream& os, const HDF5ProtobufEntry& entry)
+        {
+            os << "@" << entry.time << ": ";
+            os << "/" << entry.channel;
+            if(entry.msg)
+            {
+                os << "/" << entry.msg->GetDescriptor()->full_name();
+                os << " " << entry.msg->ShortDebugString();
+            }
+            return os;
+            
+        }
+        
+        class HDF5Plugin
+        {
+        public:
+            HDF5Plugin(goby::common::protobuf::HDF5Config* cfg) { }
+            virtual ~HDF5Plugin() { }
+            
+            virtual bool provide_entry(HDF5ProtobufEntry* entry) = 0;            
+        };
+    }
+}
+
+
+
+#endif

--- a/src/common/protobuf/hdf5.proto
+++ b/src/common/protobuf/hdf5.proto
@@ -5,5 +5,7 @@ message HDF5Config
 {
     required string output_file = 10;
 
+    optional bool include_string_fields = 20 [default = false];
+    
     extensions 1000 to max;
 }

--- a/src/common/protobuf/hdf5.proto
+++ b/src/common/protobuf/hdf5.proto
@@ -4,8 +4,10 @@ package goby.common.protobuf;
 message HDF5Config
 {
     required string output_file = 10;
-
     optional bool include_string_fields = 20 [default = false];
+
+    // for use by plugins, if desired
+    repeated string input_file = 30;
     
     extensions 1000 to max;
 }

--- a/src/common/protobuf/hdf5.proto
+++ b/src/common/protobuf/hdf5.proto
@@ -1,0 +1,9 @@
+
+package goby.common.protobuf;
+
+message HDF5Config
+{
+    required string output_file = 10;
+
+    extensions 1000 to max;
+}

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_subdirectory(log)
 
+if(enable_hdf5)
+  add_subdirectory(hdf5)
+endif()
+
 if(enable_zeromq)
   # this test fails to pass during Ubuntu automated builds
   # since Goby 2 doesn't use PGM, this is ok for now

--- a/src/test/common/hdf5/CMakeLists.txt
+++ b/src/test/common/hdf5/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_definitions(-DGOBY_LIB_DIR="${goby_LIB_DIR}")
+
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ../../acomms/dccl1/test.proto test2.proto)
+
+add_library(goby_hdf5test SHARED test-plugin.cpp ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(goby_hdf5test goby_common dccl)
+
+add_executable(goby_test_hdf5 test.cpp)
+target_link_libraries(goby_test_hdf5 goby_common)
+add_test(goby_test_hdf5 ${goby_BIN_DIR}/goby_test_hdf5)

--- a/src/test/common/hdf5/test-plugin.cpp
+++ b/src/test/common/hdf5/test-plugin.cpp
@@ -1,0 +1,192 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (2013-)
+//                     Massachusetts Institute of Technology (2007-2014)
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Binaries
+// ("The Goby Binaries").
+//
+// The Goby Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Goby Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "goby/common/hdf5_plugin.h"
+#include "goby/moos/moos_protobuf_helpers.h"
+
+#include "goby/common/time.h"
+#include "goby/util/binary.h"
+
+#include "test.pb.h"
+#include "test2.pb.h"
+
+class TestHDF5Plugin : public goby::common::HDF5Plugin
+{
+public:
+    TestHDF5Plugin(goby::common::protobuf::HDF5Config* cfg);
+    
+    
+private:
+    bool provide_entry(goby::common::HDF5ProtobufEntry* entry);
+    void fill_message(TestMsg& msg_in);
+    void fill_message(TestHDF5Message& msg);
+    
+private:
+};    
+
+
+extern "C"
+{
+    goby::common::HDF5Plugin* goby_hdf5_load(goby::common::protobuf::HDF5Config* cfg)
+    {
+        return new TestHDF5Plugin(cfg);
+    }
+    
+}
+
+
+TestHDF5Plugin::TestHDF5Plugin(goby::common::protobuf::HDF5Config* cfg)
+    : goby::common::HDF5Plugin(cfg)
+{    
+}
+
+bool TestHDF5Plugin::provide_entry(goby::common::HDF5ProtobufEntry* entry)
+{
+    static int entry_index = 0;
+
+    if(entry_index < 3 || entry_index > 7)
+    {
+        TestMsg msg;
+        fill_message(msg);
+        entry->msg = boost::shared_ptr<google::protobuf::Message>(new TestMsg(msg));
+    }
+    else
+    {
+        TestHDF5Message msg;
+        fill_message(msg);
+        entry->msg = boost::shared_ptr<google::protobuf::Message>(new TestHDF5Message(msg));
+    }
+    
+    if(entry_index < 10)
+        entry->channel = "\t/test/group1"; // add some whitespace and leading "/" - will become "test/group1"
+    else
+        entry->channel = " test/group2/"; // add some whitespace and trailing "/" - will become "test/group2"
+    
+    entry->time = goby::common::goby_time<goby::uint64>();
+
+    std::cout << *entry << std::endl;
+    
+    ++entry_index;
+
+    if(entry_index > 20)
+        return false;
+    else
+        return true;
+}
+
+
+void TestHDF5Plugin::fill_message(TestHDF5Message& msg)
+{
+    static int i = 0;
+    if(i == 0)
+    {
+        for(int j = 0; j < 10; ++j)
+            msg.add_a(++i);
+    }
+    else
+    {
+        for(int j = 0; j < 20; ++j)
+            msg.add_a(++i);
+    }
+}
+
+void TestHDF5Plugin::fill_message(TestMsg& msg_in)
+{
+    static int i = 0;
+    msg_in.set_double_default_optional(++i + 0.1);
+    msg_in.set_float_default_optional(++i + 0.2);
+
+    msg_in.set_int32_default_optional(++i);
+    msg_in.set_int64_default_optional(-++i);
+    msg_in.set_uint32_default_optional(++i);
+    msg_in.set_uint64_default_optional(++i);
+    msg_in.set_sint32_default_optional(-++i);
+    msg_in.set_sint64_default_optional(++i);
+    msg_in.set_fixed32_default_optional(++i);
+    msg_in.set_fixed64_default_optional(++i);
+    msg_in.set_sfixed32_default_optional(++i);
+    msg_in.set_sfixed64_default_optional(-++i);
+
+    msg_in.set_bool_default_optional(true);
+
+    msg_in.set_string_default_optional("abc123");
+    msg_in.set_bytes_default_optional(goby::util::hex_decode("00112233aabbcc1234"));
+    
+    msg_in.set_enum_default_optional(ENUM_C);
+    msg_in.mutable_msg_default_optional()->set_val(++i + 0.3);
+    msg_in.mutable_msg_default_optional()->mutable_msg()->set_val(++i);
+
+    msg_in.set_double_default_required(++i + 0.1);
+    msg_in.set_float_default_required(++i + 0.2);
+
+    msg_in.set_int32_default_required(++i);
+    msg_in.set_int64_default_required(-++i);
+    msg_in.set_uint32_default_required(++i);
+    msg_in.set_uint64_default_required(++i);
+    msg_in.set_sint32_default_required(-++i);
+    msg_in.set_sint64_default_required(++i);
+    msg_in.set_fixed32_default_required(++i);
+    msg_in.set_fixed64_default_required(++i);
+    msg_in.set_sfixed32_default_required(++i);
+    msg_in.set_sfixed64_default_required(-++i);
+
+    msg_in.set_bool_default_required(true);
+
+    msg_in.set_string_default_required("abc123");
+    msg_in.set_bytes_default_required(goby::util::hex_decode("00112233aabbcc1234"));
+    
+    msg_in.set_enum_default_required(ENUM_C);
+    msg_in.mutable_msg_default_required()->set_val(++i + 0.3);
+    msg_in.mutable_msg_default_required()->mutable_msg()->set_val(++i);
+
+    
+    for(int j = 0; j < 2; ++j)
+    {
+        msg_in.add_double_default_repeat(++i + 0.1);
+        msg_in.add_float_default_repeat(++i + 0.2);
+        
+        msg_in.add_int32_default_repeat(++i);
+        msg_in.add_int64_default_repeat(-++i);
+        msg_in.add_uint32_default_repeat(++i);
+        msg_in.add_uint64_default_repeat(++i);
+        msg_in.add_sint32_default_repeat(-++i);
+        msg_in.add_sint64_default_repeat(++i);
+        msg_in.add_fixed32_default_repeat(++i);
+        msg_in.add_fixed64_default_repeat(++i);
+        msg_in.add_sfixed32_default_repeat(++i);
+        msg_in.add_sfixed64_default_repeat(-++i);
+        
+        msg_in.add_bool_default_repeat(true);
+        
+        msg_in.add_string_default_repeat("abc123");
+
+        if(j)
+            msg_in.add_bytes_default_repeat(goby::util::hex_decode("00aabbcc"));
+        else
+            msg_in.add_bytes_default_repeat(goby::util::hex_decode("ffeedd12"));
+        
+        msg_in.add_enum_default_repeat(static_cast<Enum1>((++i % 3) + 1));
+        EmbeddedMsg1* em_msg = msg_in.add_msg_default_repeat();
+        em_msg->set_val(++i + 0.3);
+        em_msg->mutable_msg()->set_val(++i);
+    }
+}

--- a/src/test/common/hdf5/test-plugin.cpp
+++ b/src/test/common/hdf5/test-plugin.cpp
@@ -63,6 +63,9 @@ bool TestHDF5Plugin::provide_entry(goby::common::HDF5ProtobufEntry* entry)
 {
     static int entry_index = 0;
 
+    if(entry_index > 20)
+        return false;
+    
     if(entry_index < 3 || entry_index > 7)
     {
         TestMsg msg;
@@ -87,26 +90,54 @@ bool TestHDF5Plugin::provide_entry(goby::common::HDF5ProtobufEntry* entry)
     
     ++entry_index;
 
-    if(entry_index > 20)
-        return false;
-    else
-        return true;
+    return true;
 }
 
 
 void TestHDF5Plugin::fill_message(TestHDF5Message& msg)
 {
     static int i = 0;
+    static int i2 = 0;
+    static int i3 = 0;
+    static int i4 = 0;
     if(i == 0)
     {
         for(int j = 0; j < 10; ++j)
             msg.add_a(++i);
+
+        for(int j = 0; j < 10; ++j)
+        {
+            B* b = msg.add_b();
+            for(int k = 0; k < 20; ++k)
+            {
+                b->add_c(++i2);
+                if(k < 10)
+                    b->add_d(++i3);
+                if(k < 5)
+                    b->add_e(++i4);
+            }
+        }
+        
     }
     else
     {
         for(int j = 0; j < 20; ++j)
             msg.add_a(++i);
+
+        for(int j = 0; j < 3; ++j)
+        {
+            B* b = msg.add_b();
+            for(int k = 0; k < 2; ++k)
+            {
+                b->add_c(++i2);
+                b->add_d(++i3);
+                b->add_e(++i4);
+            }
+        }
     }
+
+    
+    
 }
 
 void TestHDF5Plugin::fill_message(TestMsg& msg_in)
@@ -159,7 +190,7 @@ void TestHDF5Plugin::fill_message(TestMsg& msg_in)
     msg_in.mutable_msg_default_required()->mutable_msg()->set_val(++i);
 
     
-    for(int j = 0; j < 2; ++j)
+    for(int j = 0; j < 3; ++j)
     {
         msg_in.add_double_default_repeat(++i + 0.1);
         msg_in.add_float_default_repeat(++i + 0.2);

--- a/src/test/common/hdf5/test-plugin.cpp
+++ b/src/test/common/hdf5/test-plugin.cpp
@@ -100,6 +100,8 @@ void TestHDF5Plugin::fill_message(TestHDF5Message& msg)
     static int i2 = 0;
     static int i3 = 0;
     static int i4 = 0;
+    static int i5 = 0;
+    static int i6 = 0;
     if(i == 0)
     {
         for(int j = 0; j < 10; ++j)
@@ -115,6 +117,13 @@ void TestHDF5Plugin::fill_message(TestHDF5Message& msg)
                     b->add_d(++i3);
                 if(k < 5)
                     b->add_e(++i4);
+            }
+            for(int l = 0; l < 3; ++l)
+            {
+                F* f = b->add_f();
+                f->set_h(++i5);
+                for(int m = 0; m < 6; ++m)
+                    f->add_g(++i6);
             }
         }
         
@@ -132,6 +141,13 @@ void TestHDF5Plugin::fill_message(TestHDF5Message& msg)
                 b->add_c(++i2);
                 b->add_d(++i3);
                 b->add_e(++i4);
+            }            
+            for(int l = 0; l < 5; ++l)
+            {
+                F* f = b->add_f();
+                f->set_h(++i5);
+                for(int m = 0; m < 8; ++m)
+                    f->add_g(++i6);
             }
         }
     }

--- a/src/test/common/hdf5/test.cpp
+++ b/src/test/common/hdf5/test.cpp
@@ -1,0 +1,46 @@
+// Copyright 2009-2016 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (2013-)
+//                     Massachusetts Institute of Technology (2007-2014)
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Binaries
+// ("The Goby Binaries").
+//
+// The Goby Binaries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// The Goby Binaries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cassert>
+#include <cstdio>
+
+#include "goby/common/logger.h"
+
+using goby::glog;
+
+int main(int argc, char* argv[])
+{
+    goby::glog.add_stream(goby::common::logger::DEBUG3, &std::cerr);
+    goby::glog.set_name(argv[0]);
+
+    std::string sys_cmd("LD_LIBRARY_PATH=" GOBY_LIB_DIR ":$LD_LIBRARY_PATH GOBY_HDF5_PLUGIN=libgoby_hdf5test.so goby_hdf5 --output_file /tmp/test.h5");
+    std::cout << "Running: [" << sys_cmd << "]" << std::endl;
+    int rc = system(sys_cmd.c_str());
+
+    if(rc == 0)
+    {
+        std::cout << "All tests passed." << std::endl;
+    }
+    
+    return rc;
+}
+
+

--- a/src/test/common/hdf5/test.cpp
+++ b/src/test/common/hdf5/test.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
     goby::glog.add_stream(goby::common::logger::DEBUG3, &std::cerr);
     goby::glog.set_name(argv[0]);
 
-    std::string sys_cmd("LD_LIBRARY_PATH=" GOBY_LIB_DIR ":$LD_LIBRARY_PATH GOBY_HDF5_PLUGIN=libgoby_hdf5test.so goby_hdf5 --output_file /tmp/test.h5");
+    std::string sys_cmd("LD_LIBRARY_PATH=" GOBY_LIB_DIR ":$LD_LIBRARY_PATH GOBY_HDF5_PLUGIN=libgoby_hdf5test.so goby_hdf5 --output_file /tmp/test.h5 --include_string_fields=true");
     std::cout << "Running: [" << sys_cmd << "]" << std::endl;
     int rc = system(sys_cmd.c_str());
 

--- a/src/test/common/hdf5/test2.proto
+++ b/src/test/common/hdf5/test2.proto
@@ -1,0 +1,4 @@
+message TestHDF5Message
+{
+    repeated double a = 1;
+}

--- a/src/test/common/hdf5/test2.proto
+++ b/src/test/common/hdf5/test2.proto
@@ -1,4 +1,12 @@
 message TestHDF5Message
 {
     repeated double a = 1;
+    repeated B b = 2;
+}
+
+message B
+{ 
+    repeated double c = 2;
+    repeated double d = 3;
+    repeated int32  e = 4;
 }

--- a/src/test/common/hdf5/test2.proto
+++ b/src/test/common/hdf5/test2.proto
@@ -9,4 +9,11 @@ message B
     repeated double c = 2;
     repeated double d = 3;
     repeated int32  e = 4;
+    repeated F f = 5;
+}
+
+message F
+{
+    repeated double g = 1;
+    optional int32 h = 2;
 }


### PR DESCRIPTION
Added new tool that can convert a collection of protobuf messages (normally from a log of some sort) into an HDF5 file that can be opened easily in Octave, MATLAB, Python, etc. for post-mission data analysis.

Tool can be extended by subclassing goby::common::HDF5Plugin and wrapping it in a shared library that exposes goby_hdf5_load (see tests/common/hdf5/test-plugin.cpp) as a C extern function. Then this shared library is loaded at runtime by the environmental variable GOBY_HDF5_PLUGIN
