### PR TITLE
Remove goby/lib and goby/bin when running make clean to remove stale generated libraries and binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ if(${APPLE})
   link_directories(/sw/lib)
 endif()
 
-set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${goby_INC_DIR}/goby)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${goby_BIN_DIR}" "${goby_LIB_DIR}" "${goby_INCLUDE_DIR}/goby")
 
 ## start adding subdirectories
 add_subdirectory(src)


### PR DESCRIPTION
Previously old libraries from prior git revisions would stay around even after a "make clean". This patch should fix that so cleaning the make targets is:

```
cd build
make clean
```

and a full cleaning (cmake and make) is:

```
cd build
make clean
rm CMakeCache.txt
```

After either case, it will be necessary to rerun cmake and make

```
cd build
cmake ..
make
```

(Or just run goby/build.sh)
