### PR TITLE
BUG:canonicalize_file_name not supported on MAC OS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ To accept this CLA, please add your name, email, and date to the list below, and
 Toby Schneider <toby@gobysoft.org> 2016-05-13
 Zac Berkowitz <zberkowitz@whoi.edu> 2016-05-19
 Stephanie Kemna <stephaniekemna@gmail.com> 2016-10-11
+Tommaso Fabbri <t.fabbri@yahoo.com> 2017-03-02

--- a/src/common/application_base.cpp
+++ b/src/common/application_base.cpp
@@ -32,7 +32,6 @@ using goby::util::as;
 
 using goby::glog;
 using namespace goby::common::logger;
-namespace fs = boost::filesystem;
 
 int goby::common::ApplicationBase::argc_ = 0;
 char** goby::common::ApplicationBase::argv_ = 0;
@@ -122,9 +121,9 @@ goby::common::ApplicationBase::ApplicationBase(google::protobuf::Message* cfg /*
            glog.is(DIE) && glog << die << "cannot write glog output to requested file: " << file_name << std::endl;
 
        remove(file_symlink.c_str());
+       namespace fs = boost::filesystem;
        fs::path canonicalized_file_name = fs::canonical(fs::path(file_name.c_str()), fs::path(file_symlink.c_str()));
        symlink(canonicalized_file_name.string().c_str(), file_symlink.c_str());       
-       //symlink(canonicalize_file_name(file_name.c_str()), file_symlink.c_str());
         
        
        glog.add_stream(base_cfg_->glog_config().file_log(i).verbosity(), fout_[i].get());

--- a/src/common/application_base.cpp
+++ b/src/common/application_base.cpp
@@ -21,6 +21,7 @@
 // along with Goby.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <boost/format.hpp>
+#include <boost/filesystem.hpp>
 
 #include "application_base.h"
 #include "goby/common/configuration_reader.h"
@@ -31,6 +32,7 @@ using goby::util::as;
 
 using goby::glog;
 using namespace goby::common::logger;
+namespace fs = boost::filesystem;
 
 int goby::common::ApplicationBase::argc_ = 0;
 char** goby::common::ApplicationBase::argv_ = 0;
@@ -120,7 +122,9 @@ goby::common::ApplicationBase::ApplicationBase(google::protobuf::Message* cfg /*
            glog.is(DIE) && glog << die << "cannot write glog output to requested file: " << file_name << std::endl;
 
        remove(file_symlink.c_str());
-       symlink(canonicalize_file_name(file_name.c_str()), file_symlink.c_str());
+       fs::path canonicalized_file_name = fs::canonical(fs::path(file_name.c_str()), fs::path(file_symlink.c_str()));
+       symlink(canonicalized_file_name.string().c_str(), file_symlink.c_str());       
+       //symlink(canonicalize_file_name(file_name.c_str()), file_symlink.c_str());
         
        
        glog.add_stream(base_cfg_->glog_config().file_log(i).verbosity(), fout_[i].get());


### PR DESCRIPTION
canonicalize_file_name not supported in Mac Os systems.
Used to boost::filesystem::canonical to overcome this limitation.

This fix has to be tested on Ubuntu systems.