### PR TITLE
Fix spamming of iFrontSeat status message if there are large skews in the system clock

### DIFF
--- a/src/apps/moos/iFrontSeat/iFrontSeat.h
+++ b/src/apps/moos/iFrontSeat/iFrontSeat.h
@@ -46,7 +46,8 @@ class iFrontSeat : public GobyMOOSApp
 
     // synchronous event
     void loop();
-
+    void status_loop();
+    
     // mail handlers
     void handle_mail_command_request(const CMOOSMsg& msg);
     void handle_mail_data_to_frontseat(const CMOOSMsg& msg);
@@ -63,8 +64,6 @@ class iFrontSeat : public GobyMOOSApp
     boost::shared_ptr<FrontSeatInterfaceBase> frontseat_;
 
     FrontSeatLegacyTranslator translator_;
-
-    double next_status_time_;
 
     static iFrontSeatConfig cfg_;
     static iFrontSeat* inst_;    


### PR DESCRIPTION
Moved status reporting to register_timer() method which properly adjusts for clock skews both forward and backward in time