### PR TITLE
Simplify GPS surfacing on Bluefin vehicles

### DIFF
--- a/src/apps/moos/iFrontSeat/legacy_translator.h
+++ b/src/apps/moos/iFrontSeat/legacy_translator.h
@@ -39,7 +39,6 @@ class FrontSeatLegacyTranslator
     void handle_mail_desired_course(const CMOOSMsg& msg);
     enum ModemRawDirection { OUTGOING, INCOMING };
     void handle_mail_modem_raw(const CMOOSMsg& msg, ModemRawDirection direction);
-    void handle_mail_gps_request(const CMOOSMsg& msg);
 
     // all for buoyancy, trim, silent
     void handle_mail_buoyancy_control(const CMOOSMsg& msg);
@@ -51,20 +50,12 @@ class FrontSeatLegacyTranslator
     void handle_driver_data_from_frontseat(const goby::moos::protobuf::FrontSeatInterfaceData& data);
     void set_fs_bs_ready_flags(goby::moos::protobuf::InterfaceState state);
     
-    void handle_gps_command_response(const goby::moos::protobuf::CommandResponse& response);
-    
     void publish_command(const goby::moos::protobuf::CommandRequest& command);
     
   private:
     iFrontSeat* ifs_;
     goby::moos::protobuf::CTDSample ctd_sample_;
     goby::moos::protobuf::DesiredCourse desired_course_;
-
-    // For GPS requesting
-    double last_pending_surface_;
-    bool gps_in_progress_;
-    int gps_request_id_;
-    
 
     // added to each request we send so as not to conflict with other requestors
     enum { LEGACY_REQUEST_IDENTIFIER = 1 << 16 };

--- a/src/moos/frontseat/bluefin/bluefin.cpp
+++ b/src/moos/frontseat/bluefin/bluefin.cpp
@@ -125,12 +125,7 @@ void BluefinFrontSeat::send_command_to_frontseat(const gpb::CommandRequest& comm
         {
             case gpb::BluefinExtraCommands::UNKNOWN_COMMAND:
             case gpb::BluefinExtraCommands::DESIRED_COURSE:
-                break;
-                
-            case gpb::BluefinExtraCommands::GPS_REQUEST:
-                glog.is(DEBUG1) && glog << "Bluefin Extra Command: GPS Fix requested by backseat."
-                                        << std::endl;
-                break;
+                break;                
 
             case gpb::BluefinExtraCommands::TRIM_ADJUST:
             {
@@ -219,8 +214,7 @@ void BluefinFrontSeat::send_command_to_frontseat(const gpb::CommandRequest& comm
         {
             glog.is(WARN) && glog << "Ignoring desired course information in this message, as an extra command was set. Only one command allowed per message." << std::endl;
         }
-        else if(outstanding_requests_.count(gpb::BluefinExtraCommands::GPS_REQUEST) &&
-                static_cast<int>(command.desired_course().depth()) == 0 &&
+        else if(static_cast<int>(command.desired_course().depth()) == 0 &&
                 static_cast<int>(command.desired_course().speed()) == 0)
         {
             type = gpb::BluefinExtraCommands::DESIRED_COURSE;   
@@ -266,10 +260,7 @@ void BluefinFrontSeat::send_command_to_frontseat(const gpb::CommandRequest& comm
         }
     }
 
-    // we enforce a request outstanding for GPS, because we need to override course requests until this
-    // GPS request is fulfilled
-    if(!bf_config_.disable_ack()
-       && (command.response_requested() || type == gpb::BluefinExtraCommands::GPS_REQUEST))
+    if(!bf_config_.disable_ack() && command.response_requested())
     {
         if(outstanding_requests_.count(type))
         {

--- a/src/moos/frontseat/bluefin/bluefin.proto
+++ b/src/moos/frontseat/bluefin/bluefin.proto
@@ -71,7 +71,7 @@ message BluefinExtraData
       required bool all_ok = 4;
   };
 
-  repeated PayloadStatus payload_status = 30;  
+  repeated PayloadStatus payload_status = 30;
 }
 
 
@@ -86,7 +86,6 @@ message BluefinExtraCommands
   {
     UNKNOWN_COMMAND = 0;
     DESIRED_COURSE = 1;
-    GPS_REQUEST = 2;
     TRIM_ADJUST = 3;
     BUOYANCY_ADJUST = 4;
     SILENT_MODE = 5;

--- a/src/moos/frontseat/bluefin/bluefin_incoming.cpp
+++ b/src/moos/frontseat/bluefin/bluefin_incoming.cpp
@@ -193,6 +193,12 @@ void BluefinFrontSeat::bfnvg(const goby::util::NMEASentence& nmea)
         status_.mutable_global_fix()->set_lon(std::numeric_limits<double>::quiet_NaN());
     }
 
+    if(nmea.as<int>(QUALITY_OF_POSITION) == 1)
+    {
+        status_.mutable_global_fix()->set_lat_source(goby::moos::protobuf::GPS);
+        status_.mutable_global_fix()->set_lon_source(goby::moos::protobuf::GPS);
+    }
+    
     status_.mutable_global_fix()->set_altitude(nmea.as<double>(ALTITUDE));
     status_.mutable_global_fix()->set_depth(nmea.as<double>(DEPTH));
     status_.mutable_pose()->set_heading(nmea.as<double>(HEADING));
@@ -345,17 +351,6 @@ void BluefinFrontSeat::bfmbe(const goby::util::NMEASentence& nmea)
 
     glog.is(DEBUG1) && glog << "Bluefin ended frontseat mission: " << behavior_type << std::endl;
     
-    if(behavior_type.find("GPS") != std::string::npos &&
-       outstanding_requests_.count(gpb::BluefinExtraCommands::GPS_REQUEST))
-    {
-        // GPS request done
-        gpb::CommandResponse response;
-        response.set_request_successful(true);
-        response.set_request_id(outstanding_requests_[gpb::BluefinExtraCommands::GPS_REQUEST].request_id());
-        signal_command_response(response);
-        outstanding_requests_.erase(gpb::BluefinExtraCommands::GPS_REQUEST);
-        return;
-    }    
 }
 
 void BluefinFrontSeat::bftop(const goby::util::NMEASentence& nmea)

--- a/src/moos/protobuf/node_status.proto
+++ b/src/moos/protobuf/node_status.proto
@@ -26,7 +26,7 @@ message NodeStatus
                              (dccl.field).min=-2.0,
                              (dccl.field).precision=1];
 
-  optional SourceSensor speed_source = 9 [(dccl.field).omit=true];  
+  optional SourceSensor speed_source = 9 [(dccl.field).omit=true, default = SOURCE_UNKNOWN];  
   optional double speed_time_lag = 11 [(dccl.field).omit=true];
 }
 
@@ -40,12 +40,15 @@ enum VehicleType { UNKNOWN = 0;
   BUOY = 6;
   OTHER = -1; }
 
-enum SourceSensor { GPS = 1;
-  DEAD_RECKONING = 2;
-  INERTIAL_MEASUREMENT_UNIT = 3;
-  PRESSURE_SENSOR = 4;
-  COMPASS = 5;
-  SIMULATION = 6;}
+enum SourceSensor {
+    SOURCE_UNKNOWN = 0;
+    GPS = 1;
+    DEAD_RECKONING = 2;
+    INERTIAL_MEASUREMENT_UNIT = 3;
+    PRESSURE_SENSOR = 4;
+    COMPASS = 5;
+    SIMULATION = 6;
+}
 
 message GeodeticCoordinate
 {
@@ -58,11 +61,11 @@ message GeodeticCoordinate
   optional double altitude = 4 [(dccl.field).max=5000.0,
                                 (dccl.field).min=-10.0,
                                 (dccl.field).precision=1];
-  
-  optional SourceSensor lat_source = 5 [(dccl.field).omit = true];
-  optional SourceSensor lon_source = 6 [(dccl.field).omit = true];
-  optional SourceSensor depth_source = 7 [(dccl.field).omit = true];
-  optional SourceSensor altitude_source = 8 [(dccl.field).omit = true];
+
+  optional SourceSensor lat_source = 5 [(dccl.field).omit = true, default = SOURCE_UNKNOWN];
+  optional SourceSensor lon_source = 6 [(dccl.field).omit = true, default = SOURCE_UNKNOWN];
+  optional SourceSensor depth_source = 7 [(dccl.field).omit = true, default = SOURCE_UNKNOWN];
+  optional SourceSensor altitude_source = 8 [(dccl.field).omit = true, default = SOURCE_UNKNOWN];
 
   // time lags (in seconds) from the message Header time
   optional double lat_time_lag = 9 [(dccl.field).omit = true];
@@ -100,12 +103,12 @@ message EulerAngles
   optional double pitch_rate = 5 [(dccl.field).omit=true];
   optional double heading_rate = 6 [(dccl.field).omit=true];  
   
-  optional SourceSensor roll_source = 10 [(dccl.field).omit = true];
-  optional SourceSensor pitch_source = 11 [(dccl.field).omit = true];
-  optional SourceSensor heading_source = 12 [(dccl.field).omit = true];
-  optional SourceSensor roll_rate_source = 13 [(dccl.field).omit = true];
-  optional SourceSensor pitch_rate_source = 14 [(dccl.field).omit = true];
-  optional SourceSensor heading_rate_source = 15 [(dccl.field).omit = true];
+  optional SourceSensor roll_source = 10 [(dccl.field).omit = true, default = SOURCE_UNKNOWN];
+  optional SourceSensor pitch_source = 11 [(dccl.field).omit = true, default = SOURCE_UNKNOWN];
+  optional SourceSensor heading_source = 12 [(dccl.field).omit = true, default = SOURCE_UNKNOWN];
+  optional SourceSensor roll_rate_source = 13 [(dccl.field).omit = true, default = SOURCE_UNKNOWN];
+  optional SourceSensor pitch_rate_source = 14 [(dccl.field).omit = true, default = SOURCE_UNKNOWN];
+  optional SourceSensor heading_rate_source = 15 [(dccl.field).omit = true, default = SOURCE_UNKNOWN];
 
   // time lags (in seconds) from the message Header time
   optional double roll_time_lag = 20 [(dccl.field).omit = true];


### PR DESCRIPTION
No longer requires a special mission from Bluefin. Instead we publish the GPS source field on lat and lon from the BFNVG quality of fix field.