### PR TITLE
Fix thread error

### DIFF
--- a/src/moos/goby_moos_app.h
+++ b/src/moos/goby_moos_app.h
@@ -355,7 +355,10 @@ template <class MOOSAppType>
 
     while(!msg_buffer_.empty() && (connected_ && started_up_))
     {
-        goby::glog << "writing from buffer: " << msg_buffer_.front().GetKey() << ": " << msg_buffer_.front().GetAsString() << std::endl;
+
+        goby::glog.is(goby::common::logger::DEBUG3) &&
+            goby::glog << "writing from buffer: " << msg_buffer_.front().GetKey() << ": " << msg_buffer_.front().GetAsString() << std::endl;
+
         MOOSAppType::m_Comms.Post(msg_buffer_.front());
         msg_buffer_.pop_front();
     }


### PR DESCRIPTION
Was getting the following error after changing the logging level on a few our our components:
```
== Misuse of goby::glog in threaded mode: must use 'goby.is(...) && glog' syntax
== Offending line: writing from buffer: CONFIG_Initial: BINARY DATA [0.1 kB]
iAISCobalt: /home/ams/src/goby/src/common/logger/flex_ostreambuf.cpp:166: virtual int goby::common::FlexOStreamBuf::sync(): Assertion `!(lock_action_ == logger_lock::lock && current_verbosity_ == logger::UNKNOWN)' failed.
Aborted (core dumped)

```

