### PR TITLE
Fix string type attribute crash.

### DIFF
--- a/src/apps/common/goby_hdf5/hdf5.cpp
+++ b/src/apps/common/goby_hdf5/hdf5.cpp
@@ -390,6 +390,8 @@ void goby::common::hdf5::Writer::write_vector(const std::string& group,
     const int rank = 1;
     hsize_t att_hs[] = {1};
     H5::DataSpace att_space(rank, att_hs, att_hs);
-    H5::Attribute att = dataset.createAttribute("default_value", datatype, att_space);
-    att.write(datatype, default_value.c_str());
+    H5::StrType att_datatype(H5::PredType::C_S1, default_value.size() + 1);
+    H5::Attribute att = dataset.createAttribute("default_value", att_datatype, att_space);
+    const H5std_string strbuf(default_value);
+    att.write(att_datatype, strbuf);
 }


### PR DESCRIPTION
When using the the `--include_string_fields` option, I was getting a seg fault. 
I found that any string with a default attribute that wasn't just an empty string caused the problem. 
Following the example outlined [here](https://support.hdfgroup.org/ftp/HDF5/examples/misc-examples/stratt.cpp) I came up with this solution that worked for me. 