### PR TITLE
2.1 fix syntax version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,16 +156,27 @@ add_subdirectory(src)
 ## configure to build/include
 file(GLOB BASE_INCLUDE_FILES RELATIVE ${goby_SRC_DIR} src/*.h)
 file(GLOB_RECURSE INCLUDE_FILES RELATIVE ${goby_SRC_DIR} 
-  src/*.proto
   src/acomms/*.h
   src/common/*.h 
   src/util/*.h 
   src/moos/*.h 
   src/pb/*.h 
   )
-foreach(I ${BASE_INCLUDE_FILES} ${INCLUDE_FILES})
+
+file(GLOB_RECURSE PROTOBUF_FILES RELATIVE ${goby_SRC_DIR}
+  src/*.proto
+  )
+
+foreach(I ${BASE_INCLUDE_FILES} ${INCLUDE_FILES} ${PROTOBUF_FILES})
   configure_file(${goby_SRC_DIR}/${I} ${goby_INC_DIR}/goby/${I} @ONLY)
 endforeach()
+
+# write the proto syntax version if required 
+foreach(I ${PROTOBUF_FILES})
+  file(READ ${goby_INC_DIR}/goby/${I} CONTENTS)
+  file(WRITE ${goby_INC_DIR}/goby/${I} "${PROTOBUF_SYNTAX_VERSION}\n${CONTENTS}")
+endforeach()
+
 
 ## copy to build/share
 file(GLOB SHARE_FILES RELATIVE ${goby_SRC_DIR} src/share/*)

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -79,7 +79,8 @@ ubuntu|debian)
             apt-get update -qq
             set +x
             packages="${packages} 
-            libdccl3-dev"
+            libdccl3-dev
+            dccl3-compiler"
         fi
         
         if [ $install_doc -ne 0 ]; then 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,10 @@ else()
   set(PROTOBUF_ALLOW_ALIAS "option allow_alias = true;" PARENT_SCOPE)
 endif()
 
+if(NOT ${PROTOC_VERSION} VERSION_LESS 3.0.0)
+  message("libprotobuf >= 3.0.0")
+  set(PROTOBUF_SYNTAX_VERSION "syntax = \"proto2\";" PARENT_SCOPE)
+endif()
 
 # dccl
 goby_find_required_package(DCCL)

--- a/src/acomms/CMakeLists.txt
+++ b/src/acomms/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 if(NOT ${PROTOC_VERSION} VERSION_LESS 2.5.0})
   if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/dccl_option_extensions.proto)
-    file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/dccl_option_extensions.proto "import public \"dccl/protobuf/option_extensions.proto\";\npackage dccl;")
+    file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/dccl_option_extensions.proto "import public \"dccl/option_extensions.proto\";\npackage dccl;")
   endif()
   if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/arithmetic_extensions.proto)
     file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/protobuf/arithmetic_extensions.proto "import public \"dccl/arithmetic/protobuf/arithmetic_extensions.proto\";")

--- a/src/acomms/protobuf/amac.proto
+++ b/src/acomms/protobuf/amac.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 import "goby/acomms/protobuf/modem_message.proto";
 
 package goby.acomms.protobuf;

--- a/src/acomms/protobuf/benthos_atm900.proto
+++ b/src/acomms/protobuf/benthos_atm900.proto
@@ -1,7 +1,7 @@
 import "goby/common/protobuf/option_extensions.proto";
 import "goby/acomms/protobuf/driver_base.proto";
 import "goby/acomms/protobuf/modem_message.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package benthos.protobuf;
 

--- a/src/acomms/protobuf/file_transfer.proto
+++ b/src/acomms/protobuf/file_transfer.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;
 

--- a/src/acomms/protobuf/iridium_driver.proto
+++ b/src/acomms/protobuf/iridium_driver.proto
@@ -1,7 +1,7 @@
 import "goby/common/protobuf/option_extensions.proto";
 import "goby/acomms/protobuf/driver_base.proto";
 import "goby/acomms/protobuf/modem_message.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message IridiumDriverConfig
 {

--- a/src/acomms/protobuf/mm_driver.proto
+++ b/src/acomms/protobuf/mm_driver.proto
@@ -1,7 +1,7 @@
 import "goby/acomms/protobuf/driver_base.proto";
 import "goby/acomms/protobuf/modem_message.proto";
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package micromodem.protobuf;
 

--- a/src/acomms/protobuf/modem_driver_status.proto
+++ b/src/acomms/protobuf/modem_driver_status.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;
 

--- a/src/acomms/protobuf/modem_message.proto
+++ b/src/acomms/protobuf/modem_message.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 import "goby/common/protobuf/option_extensions.proto";
 
 package goby.acomms.protobuf;

--- a/src/acomms/protobuf/mosh_packet.proto
+++ b/src/acomms/protobuf/mosh_packet.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;
 

--- a/src/acomms/protobuf/network_ack.proto
+++ b/src/acomms/protobuf/network_ack.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;
 

--- a/src/acomms/protobuf/network_header.proto
+++ b/src/acomms/protobuf/network_header.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 import "dccl/arithmetic/protobuf/arithmetic_extensions.proto";
 
 package goby.acomms.protobuf;

--- a/src/acomms/protobuf/route.proto
+++ b/src/acomms/protobuf/route.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;
 

--- a/src/acomms/protobuf/time_update.proto
+++ b/src/acomms/protobuf/time_update.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.acomms.protobuf;
 

--- a/src/doc/user_manual/chap_acomms.tex
+++ b/src/doc/user_manual/chap_acomms.tex
@@ -80,7 +80,7 @@ Integer (!(u)int32!, !(u)int64!) fields take a !max! and !min! value\footnote{th
 Booleans (!bool!) and enumerations (!enum!) are automatically bounded their nature, and require no additional configuration. Strings (!string!) (which are generally discouraged on an acoustic link since they tend to be sparse) are bounded by a maximum length. Similarly, !bytes! are pre-encoded data that are passed through unmodified in DCCL. Applying these bounds to the example message above (along with the required .proto file imports) yields:
 
 \begin{boxedverbatim}
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package example;
 

--- a/src/moos/frontseat/waveglider/waveglider_sv2_frontseat_driver.proto
+++ b/src/moos/frontseat/waveglider/waveglider_sv2_frontseat_driver.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.moos.protobuf;
 

--- a/src/moos/protobuf/bluefin_driver.proto
+++ b/src/moos/protobuf/bluefin_driver.proto
@@ -1,6 +1,6 @@
 import "goby/acomms/protobuf/driver_base.proto";
 import "goby/acomms/protobuf/modem_message.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.moos.protobuf;
 

--- a/src/moos/protobuf/ctd_sample.proto
+++ b/src/moos/protobuf/ctd_sample.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.moos.protobuf;
 message CTDSample

--- a/src/moos/protobuf/desired_course.proto
+++ b/src/moos/protobuf/desired_course.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.moos.protobuf;
 

--- a/src/moos/protobuf/node_status.proto
+++ b/src/moos/protobuf/node_status.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.moos.protobuf;
 

--- a/src/moos/protobuf/ufield_sim_driver.proto
+++ b/src/moos/protobuf/ufield_sim_driver.proto
@@ -1,7 +1,7 @@
 import "goby/acomms/protobuf/driver_base.proto";
 import "goby/moos/protobuf/modem_id_lookup.proto";
 import "goby/acomms/protobuf/modem_message.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.moos.protobuf;
 

--- a/src/moos/transitional/dccl_transitional.cpp
+++ b/src/moos/transitional/dccl_transitional.cpp
@@ -127,7 +127,7 @@ void goby::transitional::DCCLTransitionalCodec::convert_xml_message_file(
     if (!fout.is_open())
         throw(goby::acomms::DCCLException("Could not open " + *proto_file + " for writing"));
 
-    fout << "import \"dccl/protobuf/option_extensions.proto\";" << std::endl;
+    fout << "import \"dccl/option_extensions.proto\";" << std::endl;
     fout << "import \"goby/common/protobuf/option_extensions.proto\";" << std::endl;
 
     for (int i = 0, n = added_ids.size(); i < n; ++i)

--- a/src/pb/protobuf/header.proto
+++ b/src/pb/protobuf/header.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 // required fields will be filled in for you by ApplicationBase
 // if you choose not to do so yourself

--- a/src/pb/protobuf/pb_modem_driver.proto
+++ b/src/pb/protobuf/pb_modem_driver.proto
@@ -2,7 +2,7 @@ import "goby/acomms/protobuf/driver_base.proto"; // load up message DriverBaseCo
 import "goby/acomms/protobuf/modem_message.proto"; // load up message ModemTransmission
 
 import "goby/common/protobuf/zero_mq_node_config.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message PBDriverConfig
 {

--- a/src/share/examples/acomms/chat/chat.proto
+++ b/src/share/examples/acomms/chat/chat.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message ChatMessage
 {

--- a/src/share/examples/acomms/dccl/dccl_simple/simple.proto
+++ b/src/share/examples/acomms/dccl/dccl_simple/simple.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message Simple
 {

--- a/src/share/examples/acomms/dccl/two_message/two_message.proto
+++ b/src/share/examples/acomms/dccl/two_message/two_message.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 message GoToCommand
 {
     option (dccl.msg).id = 125;

--- a/src/share/examples/moos/gobyexample_protobuf/simple_status.proto
+++ b/src/share/examples/moos/gobyexample_protobuf/simple_status.proto
@@ -1,5 +1,5 @@
 // include the DCCL extensions to Google Protobuf
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 package goby.example;
 

--- a/src/test/acomms/dccl1/test.proto
+++ b/src/test/acomms/dccl1/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 enum Enum1
 {

--- a/src/test/acomms/dccl10/test.proto
+++ b/src/test/acomms/dccl10/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 import "dccl/arithmetic/protobuf/arithmetic_extensions.proto";
 
 enum Enum1

--- a/src/test/acomms/dccl2/test.proto
+++ b/src/test/acomms/dccl2/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message CustomMsg
 {

--- a/src/test/acomms/dccl3/header.proto
+++ b/src/test/acomms/dccl3/header.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 // required fields will be filled in for you by ApplicationBase
 // if you choose not to do so yourself

--- a/src/test/acomms/dccl3/test.proto
+++ b/src/test/acomms/dccl3/test.proto
@@ -1,5 +1,5 @@
 import "goby/common/protobuf/option_extensions.proto";
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 import "goby/test/acomms/dccl3/header.proto";
 
 message GobyMessage

--- a/src/test/acomms/dccl4/test.proto
+++ b/src/test/acomms/dccl4/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 import "goby/test/acomms/dccl3/header.proto";
 
 message GobyMessage1

--- a/src/test/acomms/dccl6/test.proto
+++ b/src/test/acomms/dccl6/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message ShortIDMsg
 {

--- a/src/test/acomms/dccl7/test.proto
+++ b/src/test/acomms/dccl7/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message BytesMsg
 {

--- a/src/test/acomms/dccl8/test.proto
+++ b/src/test/acomms/dccl8/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 import "goby/test/acomms/dccl3/header.proto";
 
 message GobyMessage1

--- a/src/test/acomms/dccl9/test.proto
+++ b/src/test/acomms/dccl9/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message MiniUser
 {

--- a/src/test/acomms/queue1/test.proto
+++ b/src/test/acomms/queue1/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message TestMsg
 {

--- a/src/test/acomms/queue5/test.proto
+++ b/src/test/acomms/queue5/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message GobyMessage
 {

--- a/src/test/acomms/queue6/test.proto
+++ b/src/test/acomms/queue6/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 
 message GobyMessage
 {

--- a/src/test/acomms/route1/test.proto
+++ b/src/test/acomms/route1/test.proto
@@ -1,4 +1,4 @@
-import "dccl/protobuf/option_extensions.proto";
+import "dccl/option_extensions.proto";
 import "goby/common/protobuf/option_extensions.proto";
 
 message RouteMessage


### PR DESCRIPTION
Backports fix from Goby3 for adding `syntax="proto2"` to all .proto files for Protobuf library versions >= 3.0.0.

Fixes #42 