### PR TITLE
Added contents of triggering message to signal_queue_size_change

### DIFF
--- a/src/acomms/protobuf/queue.proto
+++ b/src/acomms/protobuf/queue.proto
@@ -86,6 +86,13 @@ message QueueSize
 {
     required uint32 dccl_id = 1;
     required uint32 size = 2;
+
+    message EncodedMessage
+    {
+        required string full_name = 1;
+        required bytes data = 2;
+    }
+    optional EncodedMessage triggering_message = 10;
 }
 
 message QueueFlush

--- a/src/acomms/queue/queue.cpp
+++ b/src/acomms/queue/queue.cpp
@@ -384,7 +384,9 @@ bool goby::acomms::Queue::get_priority_values(double* priority,
     }
 }
 
-bool goby::acomms::Queue::pop_message(unsigned frame)
+bool goby::acomms::Queue::pop_message(unsigned frame,
+                                      boost::shared_ptr<google::protobuf::Message>& removed_msg)
+
 {
     std::list<QueuedMessage>::iterator back_it = messages_.end();
     --back_it; // gives us "back" iterator
@@ -399,6 +401,7 @@ bool goby::acomms::Queue::pop_message(unsigned frame)
         if (!it->meta.ack_requested())
         {
             stream_for_pop(*it);
+            removed_msg = it->dccl_msg;
             messages_.erase(it);
             return true;
         }

--- a/src/acomms/queue/queue.h
+++ b/src/acomms/queue/queue.h
@@ -73,7 +73,7 @@ class Queue
                                 const google::protobuf::Message& msg);
 
     goby::acomms::QueuedMessage give_data(unsigned frame);
-    bool pop_message(unsigned frame);
+    bool pop_message(unsigned frame, boost::shared_ptr<google::protobuf::Message>& removed_msg);
     bool pop_message_ack(unsigned frame, boost::shared_ptr<google::protobuf::Message>& removed_msg);
     void stream_for_pop(const QueuedMessage& queued_msg);
 

--- a/src/acomms/queue/queue_manager.h
+++ b/src/acomms/queue/queue_manager.h
@@ -227,7 +227,7 @@ class QueueManager
     QueueManager& operator=(const QueueManager&);
     //@}
 
-    void qsize(Queue* q);
+    void qsize(Queue* q, const google::protobuf::Message* triggering_message);
 
     // finds the %queue with the highest priority
     Queue* find_next_sender(const protobuf::ModemTransmission& message, const std::string& data,


### PR DESCRIPTION
Add the DCCL message that triggers the queue size change, if one exists. For a shrinking queue this is the message that was just popped, for a growing queue this is the message that was just pushed.

Rather than modify the signature of `signal_queue_size_changed`, I added this as an additional optional field to the QueueSize message.

@glgrobe Could you please review and see if this fits your needs.

This block of the Queue3 unit test shows how to extract the encoded message:
https://github.com/GobySoft/goby/compare/2.1-queue-size-add-encoded-message?expand=1#diff-0846765b1bb6e76a7fed8bdf73a334e9R203