### PR TITLE
goby_frontseat_waveglider_sv2: add .so version

### DIFF
--- a/src/moos/frontseat/waveglider/CMakeLists.txt
+++ b/src/moos/frontseat/waveglider/CMakeLists.txt
@@ -9,5 +9,7 @@ target_link_libraries(goby_frontseat_waveglider_sv2
   goby_moos
   ${PROTOBUF_LIBRARIES})
 
+set_target_properties(goby_frontseat_waveglider_sv2 PROPERTIES VERSION "${GOBY_VERSION}" SOVERSION "${GOBY_SOVERSION}")
+
 configure_file(iFrontSeat_waveglider.in ${goby_BIN_DIR}/iFrontSeat_waveglider @ONLY)
 goby_install_lib(goby_frontseat_waveglider_sv2)

--- a/src/moos/frontseat/waveglider/iFrontSeat_waveglider.in
+++ b/src/moos/frontseat/waveglider/iFrontSeat_waveglider.in
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:@goby_LIB_DIR@ IFRONTSEAT_DRIVER_LIBRARY=libgoby_frontseat_waveglider_sv2.so exec iFrontSeat $@
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:@goby_LIB_DIR@ IFRONTSEAT_DRIVER_LIBRARY=libgoby_frontseat_waveglider_sv2.so.@GOBY_SOVERSION@ exec iFrontSeat $@
 


### PR DESCRIPTION
The `goby_frontseat_waveglider_sv2` library is missing its version suffix.