### PR TITLE
Fixed building on RHEL/CentOS 8.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -168,7 +168,8 @@ endif()
 ## set flags
 option(build_common "Build the Goby Common library" ON)  
 
-
+## Enable use of deprectect Proj API
+add_definitions(-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H)
 
 macro(goby_install_lib target_lib)
   set_property(TARGET ${target_lib} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES

--- a/src/acomms/amac/mac_manager.h
+++ b/src/acomms/amac/mac_manager.h
@@ -34,6 +34,7 @@
 #include "goby/acomms/protobuf/amac.pb.h"
 #include "goby/acomms/protobuf/amac_config.pb.h"
 #include "goby/acomms/protobuf/modem_message.pb.h"
+#include "goby/common/io_service.h"
 #include "goby/common/time.h"
 #include "goby/util/as.h"
 

--- a/src/acomms/modemdriver/iridium_driver.cpp
+++ b/src/acomms/modemdriver/iridium_driver.cpp
@@ -21,6 +21,7 @@
 // along with Goby.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <algorithm>
+#include <boost/version.hpp>
 
 #include "iridium_driver.h"
 
@@ -94,7 +95,11 @@ void goby::acomms::IridiumDriver::modem_init()
 
         if (driver_cfg_.GetExtension(IridiumDriverConfig::use_dtr) && modem().active() && !dtr_set)
         {
+#if BOOST_VERSION < 104700
             serial_fd_ = dynamic_cast<util::SerialClient&>(modem()).socket().native();
+#else
+            serial_fd_ = dynamic_cast<util::SerialClient&>(modem()).socket().native_handle();
+#endif
             set_dtr(true);
             glog.is(DEBUG1) && glog << group(glog_out_group()) << "DTR is: " << query_dtr()
                                     << std::endl;

--- a/src/acomms/modemdriver/iridium_shore_driver.cpp
+++ b/src/acomms/modemdriver/iridium_shore_driver.cpp
@@ -24,6 +24,7 @@
 
 #include "goby/acomms/modemdriver/driver_exception.h"
 #include "goby/acomms/modemdriver/rudics_packet.h"
+#include "goby/common/io_service.h"
 #include "goby/common/logger.h"
 #include "goby/common/time.h"
 #include "goby/util/binary.h"

--- a/src/acomms/modemdriver/iridium_shore_driver.h
+++ b/src/acomms/modemdriver/iridium_shore_driver.h
@@ -34,6 +34,7 @@
 #include "goby/acomms/protobuf/iridium_sbd_directip.pb.h"
 #include "goby/acomms/protobuf/iridium_shore_driver.pb.h"
 #include "goby/common/time.h"
+#include "goby/common/io_service.h"
 
 namespace goby
 {

--- a/src/acomms/modemdriver/iridium_shore_rudics.h
+++ b/src/acomms/modemdriver/iridium_shore_rudics.h
@@ -29,6 +29,7 @@
 #include <boost/signals2.hpp>
 
 #include "goby/common/time.h"
+#include "goby/common/io_service.h"
 #include "goby/util/binary.h"
 
 namespace goby

--- a/src/acomms/modemdriver/iridium_shore_sbd.h
+++ b/src/acomms/modemdriver/iridium_shore_sbd.h
@@ -26,6 +26,7 @@
 #include "goby/acomms/protobuf/iridium_sbd_directip.pb.h"
 #include "goby/acomms/protobuf/rudics_shore.pb.h"
 #include "goby/common/time.h"
+#include "goby/common/io_service.h"
 #include "goby/util/binary.h"
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>

--- a/src/acomms/modemdriver/mm_driver.cpp
+++ b/src/acomms/modemdriver/mm_driver.cpp
@@ -25,6 +25,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/assign.hpp>
 #include <boost/foreach.hpp>
+#include <boost/version.hpp>
 
 #include <dccl/bitset.h>
 
@@ -112,7 +113,11 @@ void goby::acomms::MMDriver::startup(const protobuf::DriverConfig& cfg)
         // Grab our native file descrpitor for the serial port.  Only works for linux.
         // Used to change control lines (e.g. RTS) w/ linux through IOCTL calls.
         // Would need #ifdef's for conditional compling if other platforms become desired.
+#if BOOST_VERSION < 104700
         serial_fd_ = dynamic_cast<util::SerialClient&>(modem()).socket().native();
+#else
+        serial_fd_ = dynamic_cast<util::SerialClient&>(modem()).socket().native_handle();
+#endif
 
         // The MM2 (at least, possibly MM1 as well) has an issue where serial comms are
         // garbled when RTS is asserted and hardware flow control is disabled (HFC0).

--- a/src/acomms/modemdriver/udp_driver.cpp
+++ b/src/acomms/modemdriver/udp_driver.cpp
@@ -24,6 +24,7 @@
 
 #include "goby/acomms/modemdriver/driver_exception.h"
 #include "goby/acomms/modemdriver/mm_driver.h"
+#include "goby/common/io_service.h"
 #include "goby/common/logger.h"
 #include "goby/util/binary.h"
 

--- a/src/acomms/modemdriver/udp_driver.h
+++ b/src/acomms/modemdriver/udp_driver.h
@@ -24,6 +24,7 @@
 #define UDPModemDriver20120409H
 
 #include "goby/common/time.h"
+#include "goby/common/io_service.h"
 
 #include "goby/acomms/modemdriver/driver_base.h"
 #include "goby/acomms/protobuf/udp_driver.pb.h"

--- a/src/apps/acomms/goby_modemdriver/modemdriver.cpp
+++ b/src/apps/acomms/goby_modemdriver/modemdriver.cpp
@@ -19,6 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Goby.  If not, see <http://www.gnu.org/licenses/>.
 
+#include "goby/common/io_service.h"
 #include "goby/common/logger.h"
 #include "goby/common/logger/term_color.h"
 #include "goby/common/zeromq_service.h"

--- a/src/apps/acomms/goby_mosh_relay/mosh_relay.cpp
+++ b/src/apps/acomms/goby_mosh_relay/mosh_relay.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/asio.hpp>
 
+#include "goby/common/io_service.h"
 #include "goby/common/logger.h"
 
 #include "goby/pb/application.h"

--- a/src/apps/moos/pAcommsHandler/pAcommsHandler.cpp
+++ b/src/apps/moos/pAcommsHandler/pAcommsHandler.cpp
@@ -33,6 +33,7 @@
 #include "goby/acomms/modemdriver/iridium_driver.h"
 #include "goby/acomms/modemdriver/iridium_shore_driver.h"
 #include "goby/acomms/modemdriver/udp_driver.h"
+#include "goby/common/io_service.h"
 #include "goby/moos/moos_bluefin_driver.h"
 #include "goby/moos/moos_protobuf_helpers.h"
 #include "goby/moos/moos_ufield_sim_driver.h"

--- a/src/apps/moos/pAcommsHandler/pAcommsHandler.h
+++ b/src/apps/moos/pAcommsHandler/pAcommsHandler.h
@@ -32,6 +32,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include "goby/acomms.h"
+#include "goby/common/io_service.h"
 #include "goby/util.h"
 
 #ifdef ENABLE_GOBY_V1_TRANSITIONAL_SUPPORT

--- a/src/apps/moos/pTranslator/pTranslator.h
+++ b/src/apps/moos/pTranslator/pTranslator.h
@@ -26,6 +26,7 @@
 
 #include <boost/asio/deadline_timer.hpp>
 
+#include "goby/common/io_service.h"
 #include "goby/moos/goby_moos_app.h"
 #include "goby/moos/moos_translator.h"
 #include "goby/util/dynamic_protobuf_manager.h"

--- a/src/common/io_service.h
+++ b/src/common/io_service.h
@@ -1,0 +1,45 @@
+// Copyright 2009-2018 Toby Schneider (http://gobysoft.org/index.wt/people/toby)
+//                     GobySoft, LLC (2013-)
+//                     Massachusetts Institute of Technology (2007-2014)
+//                     Community contributors (see AUTHORS file)
+//
+//
+// This file is part of the Goby Underwater Autonomy Project Libraries
+// ("The Goby Libraries").
+//
+// The Goby Libraries are free software: you can redistribute them and/or modify
+// them under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// The Goby Libraries are distributed in the hope that they will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Goby.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#ifndef IO_SERVICE20200522H
+#define IO_SERVICE20200522H
+
+#include <boost/version.hpp>
+
+// boost::asio::io_service was deprected in 1.66
+#if BOOST_VERSION >= 106600
+
+#include <boost/asio.hpp>
+
+namespace boost
+{
+namespace asio
+{
+  typedef io_context io_service;
+} // namespace asio
+} // namespace boost
+
+#endif
+
+#endif
+


### PR DESCRIPTION
Fixed building on RHEL/CentOS 8. There were three main issues
with compiling on RHEL/CentOS 8:

  1. ```boost::asio::io_service``` was deprecated in 1.66. The
     ```common/io_service.h``` header creates a typedefs io_context
     to io_service if the boost version is greater than or equal
     to 1.66.
  2. ```boost::asio::basic_stream_socket``` ```native()``` method deprecated
     in 1.47. The version of boost is checked when the ```native()```
     is used and switches to ```native_handle()``` if the version is
     greater than 1.47.
  3. Using ```proj_api.h``` is deprecated. Added a define to
     ```src/CMakeLists.txt``` for ```ACCEPT_USE_OF_DEPRECATED_PROJ_API_H```.

Tested on CentOS 7 and CentOS 8. 

Fixes #51.

Additional Note:
- The ```src/CMakeLists.txt``` defines ```MOOS_LIBRARIES``` to be ```MOOS```. This should possibly get changed to using the namespaced version ```MOOS::MOOS```.
- This pull request does not modify the version in the CMakeLists.txt. If accepted, the version should probably get updated to 2.1.15 and a new tag created...
